### PR TITLE
Optimize models containing lists of other models

### DIFF
--- a/wom/models/groups/models.py
+++ b/wom/models/groups/models.py
@@ -317,20 +317,24 @@ class ComputedMetricLeader(BaseModel):
 class MetricLeaders(BaseModel):
     """The leaders for each metric in a group."""
 
-    skills: list[SkillLeader]
-    """A list of [`SkillLeader`][wom.SkillLeader]'s for each skill."""
-
-    bosses: list[BossLeader]
-    """A list of all [`BossLeader`][wom.BossLeader]'s for each boss."""
-
-    activities: list[ActivityLeader]
-    """A list of all [`ActivityLeader`][wom.ActivityLeader]'s for each
-    activity.
+    skills: dict[enums.Skills, SkillLeader]
+    """A mapping of [`Skills`][wom.Skills] keys to [`SkillLeader`]
+    [wom.SkillLeader] values.
     """
 
-    computed: list[ComputedMetricLeader]
-    """A list of all [`ComputedMetricLeader`]
-    [wom.ComputedMetricLeader]'s for each computed metric.
+    bosses: dict[enums.Bosses, BossLeader]
+    """A mapping of [`Bosses`][wom.Bosses] keys to [`BossLeader`]
+    [wom.BossLeader] values.
+    """
+
+    activities: dict[enums.Activities, ActivityLeader]
+    """A mapping of [`Activities`][wom.Activities] keys to [`ActivityLeader`]
+    [wom.ActivityLeader] values.
+    """
+
+    computed: dict[enums.ComputedMetrics, ComputedMetricLeader]
+    """A mapping of [`ComputedMetrics`][wom.ComputedMetrics] keys to
+    [`ComputedMetricLeader`][wom.ComputedMetricLeader] values.
     """
 
 
@@ -351,6 +355,6 @@ class GroupStatistics(BaseModel):
     """The average group statistics in a [`Snapshot`][wom.Snapshot]."""
 
     metric_leaders: MetricLeaders
-    """The [`MetricLeader`][wom.MetricLeaders]'s in this group for each
+    """The [`MetricLeaders`][wom.MetricLeaders] in this group for each
     metric.
     """

--- a/wom/models/names/models.py
+++ b/wom/models/names/models.py
@@ -38,20 +38,25 @@ class NameChange(BaseModel):
 
     id: int
     """The unique ID of this name change."""
+
     player_id: int
     """The player ID associated with the name change."""
+
     old_name: str
     """The old username of the player."""
+
     new_name: str
     """The new username of the player."""
+
     status: NameChangeStatus
-    """The [`status`][wom.NameChangeStatus] of the name
-    change.
-    """
+    """The [`status`][wom.NameChangeStatus] of the name change."""
+
     resolved_at: datetime | None
     """The date the name change was approved or denied."""
+
     updated_at: datetime
     """The date the name change was updated."""
+
     created_at: datetime
     """The date the name change was created."""
 

--- a/wom/models/players/models.py
+++ b/wom/models/players/models.py
@@ -127,24 +127,24 @@ class ComputedMetric(BaseModel):
 class SnapshotData(BaseModel):
     """The data associated with this snapshot."""
 
-    skills: list[Skill]
-    """A list of all [`Skills`][wom.Skill] stored in this
-    snapshot.
+    skills: dict[enums.Skills, Skill]
+    """A mapping of [`Skills`][wom.Skills] keys to [`Skill`][wom.Skill] values
+    from this snapshot.
     """
 
-    bosses: list[Boss]
-    """A list of all [`Bosses`][wom.Boss] stored in this
-    snapshot.
+    bosses: dict[enums.Bosses, Boss]
+    """A mapping of [`Bosses`][wom.Bosses] keys to [`Boss`][wom.Boss] values
+    from this snapshot.
     """
 
-    activities: list[Activity]
-    """A list of all [`Activities`][wom.Activity] stored in this
-    snapshot.
+    activities: dict[enums.Activities, Activity]
+    """A mapping of [`Activities`][wom.Activities] keys to [`Activity`]
+    [wom.Activity] values from this snapshot.
     """
 
-    computed: list[ComputedMetric]
-    """A list of all [`ComputedMetrics`][wom.ComputedMetric] stored in
-    this snapshot.
+    computed: dict[enums.ComputedMetrics, ComputedMetric]
+    """A mapping of [`ComputedMetrics`][wom.ComputedMetrics] keys to
+    [`ComputedMetric`][wom.ComputedMetric] values from this snapshot.
     """
 
 
@@ -429,17 +429,25 @@ class ComputedGains(BaseModel):
 class PlayerGainsData(BaseModel):
     """Contains all the player gains data."""
 
-    skills: list[SkillGains]
-    """A list of all [`SkillGains`][wom.SkillGains]."""
+    skills: dict[enums.Skills, SkillGains]
+    """A mapping of [`Skills`][wom.Skills] keys to [`SkillGains`]
+    [wom.SkillGains] values.
+    """
 
-    bosses: list[BossGains]
-    """A list of all [`BossGains`][wom.BossGains]."""
+    bosses: dict[enums.Bosses, BossGains]
+    """A mapping of [`Bosses`][wom.Bosses] keys to [`BossGains`]
+    [wom.BossGains] values.
+    """
 
-    activities: list[ActivityGains]
-    """A list of all [`ActivityGains`][wom.ActivityGains]."""
+    activities: dict[enums.Activities, ActivityGains]
+    """A mapping of [`Activities`][wom.Activities] keys to [`ActivityGains`]
+    [wom.ActivityGains] values.
+    """
 
-    computed: list[ComputedGains]
-    """A list of all [`ComputedGains`][wom.ComputedGains]."""
+    computed: dict[enums.ComputedMetrics, ComputedGains]
+    """A mapping of [`ComputedMetrics`][wom.ComputedMetrics] keys to
+    [`ComputedGains`] [wom.ComputedGains] values.
+    """
 
 
 @attrs.define(init=False)

--- a/wom/models/records/models.py
+++ b/wom/models/records/models.py
@@ -44,9 +44,7 @@ class Record(BaseModel):
     """The player ID associated with this record."""
 
     period: enums.Period
-    """The [`Period`][wom.Period] over which this record was
-    achieved.
-    """
+    """The [`Period`][wom.Period] over which this record was achieved."""
 
     metric: enums.Metric
     """The [`Metric`][wom.Metric] measured in this record."""

--- a/wom/serializer.py
+++ b/wom/serializer.py
@@ -34,7 +34,7 @@ from wom import models
 __all__ = ("Serializer",)
 
 T = t.TypeVar("T")
-TransformT = t.Callable[..., t.Any] | None
+TransformT = t.Callable[[t.Any], t.Any] | None
 AchievementT = t.TypeVar("AchievementT", models.Achievement, models.AchievementProgress)
 HasMetricsT = t.TypeVar(
     "HasMetricsT",


### PR DESCRIPTION
This PR alters `MetricLeaders` , `PlayerGainsData`, and `SnapshotData` to hold their inner models inside a dictionary rather than a list for O(1) lookups by the end user.

Closes #7 