### PR TITLE
Fix support for python 3.8 and 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        session: [types, formatting, imports, licensing, coverage]
+        session: [types, formatting, imports, licensing, alls]
     runs-on: ubuntu-latest
 
     steps:

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -35,7 +35,7 @@ from wom import Skills
 from wom import models
 
 AchievementT = t.TypeVar("AchievementT", models.Achievement, models.AchievementProgress)
-DictT = dict[str, t.Any]
+DictT = t.Dict[str, t.Any]
 
 serializer = Serializer()
 

--- a/wom/client.py
+++ b/wom/client.py
@@ -111,10 +111,10 @@ class Client:
 
     def __init__(
         self,
-        api_key: str | None = None,
+        api_key: t.Optional[str] = None,
         *,
-        user_agent: str | None = None,
-        api_base_url: str | None = None,
+        user_agent: t.Optional[str] = None,
+        api_base_url: t.Optional[str] = None,
     ) -> None:
         self._serializer = serializer.Serializer()
         self._http = services.HttpService(api_key, user_agent, api_base_url)
@@ -222,6 +222,11 @@ class Client:
 
         Args:
             user_agent: The new user agent to use.
+
+        !!! note
+
+            To remove a previously set user agent, call this method
+            with an empty string as the user agent.
 
         ??? example
 

--- a/wom/enums.py
+++ b/wom/enums.py
@@ -58,7 +58,7 @@ class BaseEnum(Enum):
         return cls(value)
 
     @classmethod
-    def from_str_maybe(cls: t.Type[T], value: str) -> T | None:
+    def from_str_maybe(cls: t.Type[T], value: str) -> t.Optional[T]:
         """Attempt to generate this enum from the given value.
 
         Args:
@@ -84,11 +84,6 @@ class Metric(BaseEnum):
         or [`Skills`][wom.Skills].
     """
 
-    # TODO: Do we even need this method??????????
-    # @classmethod
-    # def _filter_on_value(cls: t.Type[T], value: str) -> set[T]:
-    #     return set(filter(lambda x: x.value == value, cls))  # type: ignore
-
     @classmethod
     def from_str(cls: t.Type[T], value: str) -> T:
         if cls is not Metric:
@@ -105,7 +100,7 @@ class Metric(BaseEnum):
         raise RuntimeError(f"No {cls} variant for {value!r}.")
 
     @classmethod
-    def from_str_maybe(cls: t.Type[T], value: str) -> T | None:
+    def from_str_maybe(cls: t.Type[T], value: str) -> t.Optional[T]:
         if cls is not Metric:
             return super(Metric, cls).from_str_maybe(value)  # pyright: ignore
 

--- a/wom/models/base.py
+++ b/wom/models/base.py
@@ -32,7 +32,7 @@ import attrs
 class BaseModel:
     """The base model all library models inherit from."""
 
-    def to_dict(self) -> dict[str, t.Any]:
+    def to_dict(self) -> t.Dict[str, t.Any]:
         """Converts this class into a dictionary.
 
         Returns:

--- a/wom/models/competitions/models.py
+++ b/wom/models/competitions/models.py
@@ -23,6 +23,7 @@
 
 from __future__ import annotations
 
+import typing as t
 from datetime import datetime
 
 import attrs
@@ -86,7 +87,7 @@ class Competition(BaseModel):
     ends_at: datetime
     """The date the competition ended at."""
 
-    group_id: int | None
+    group_id: t.Optional[int]
     """The optional group id associated with the competition."""
 
     score: int
@@ -101,7 +102,7 @@ class Competition(BaseModel):
     participant_count: int
     """The number of players participating."""
 
-    group: Group | None
+    group: t.Optional[Group]
     """The [`Group`][wom.Group] associated with the competition, if
     there is one.
     """
@@ -117,7 +118,7 @@ class Participation(BaseModel):
     competition_id: int
     """The ID of the competition associated with this participation."""
 
-    team_name: str | None
+    team_name: t.Optional[str]
     """The optional team name associated with this participation."""
 
     created_at: datetime
@@ -194,7 +195,7 @@ class CompetitionDetail(BaseModel):
     competition: Competition
     """The [`Competition`][wom.Competition] that is being detailed."""
 
-    participations: list[CompetitionParticipationDetail]
+    participations: t.List[CompetitionParticipationDetail]
     """A list of [`CompetitionParticipationDetail`]
     [wom.CompetitionParticipationDetail] participations for this
     competition.
@@ -219,7 +220,7 @@ class Top5ProgressResult(BaseModel):
     player: Player
     """The [`Player`][wom.Player] who made top 5 progress."""
 
-    history: list[CompetitionHistoryDataPoint]
+    history: t.List[CompetitionHistoryDataPoint]
     """A list of [CompetitionHistoryDataPoints]
     [wom.CompetitionHistoryDataPoint] making up the history
     of this top 5 progress result.
@@ -242,14 +243,14 @@ class Team(BaseModel):
         data to some endpoints.
     """
 
-    def __init__(self, name: str, participants: list[str]) -> None:
+    def __init__(self, name: str, participants: t.List[str]) -> None:
         self.name = name
         self.participants = participants
 
     name: str
     """The name of the team."""
 
-    participants: list[str]
+    participants: t.List[str]
     """A list of participant usernames on the team."""
 
 
@@ -260,12 +261,12 @@ class CompetitionWithParticipations(BaseModel):
     competition: Competition
     """The [`Competition`][wom.Competition] itself."""
 
-    participations: list[CompetitionParticipation]
+    participations: t.List[CompetitionParticipation]
     """A list containing the [`CompetitionParticipations`]
     [wom.CompetitionParticipation].
     """
 
-    verification_code: str | None
+    verification_code: t.Optional[str]
     """The verification code for the competition.
 
     !!! note

--- a/wom/models/groups/models.py
+++ b/wom/models/groups/models.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 
+import typing as t
 from datetime import datetime
 
 import attrs
@@ -66,10 +67,10 @@ class Group(BaseModel):
     clan_chat: str
     """The clan chat for this group."""
 
-    description: str | None
+    description: t.Optional[str]
     """The groups optional description."""
 
-    homeworld: int | None
+    homeworld: t.Optional[int]
     """The groups optional homeworld."""
 
     verified: bool
@@ -95,10 +96,10 @@ class GroupDetail(BaseModel):
     group: Group
     """The [`Group`][wom.Group] itself."""
 
-    memberships: list[GroupMembership]
+    memberships: t.List[GroupMembership]
     """A list of [`GroupMemberships`][wom.GroupMembership]."""
 
-    verification_code: str | None
+    verification_code: t.Optional[str]
     """The optional verification code for the group.
 
     !!! note
@@ -117,7 +118,7 @@ class Membership(BaseModel):
     group_id: int
     """The group ID this membership belongs to."""
 
-    role: GroupRole | None
+    role: t.Optional[GroupRole]
     """The optional [`GroupRole`][wom.GroupRole] for this membership."""
 
     created_at: datetime
@@ -165,14 +166,14 @@ class GroupMemberFragment(BaseModel):
         data to some endpoints.
     """
 
-    def __init__(self, username: str, role: GroupRole | None = None) -> None:
+    def __init__(self, username: str, role: t.Optional[GroupRole] = None) -> None:
         self.username = username
         self.role = role
 
     username: str
     """The group members username."""
 
-    role: GroupRole | None
+    role: t.Optional[GroupRole]
     """The optional [`GroupRole`][wom.GroupRole] for the member.
     """
 
@@ -184,12 +185,12 @@ class GroupHiscoresEntry(BaseModel):
     player: Player
     """The [`Player`][wom.Player] responsible for the entry."""
 
-    data: (
-        GroupHiscoresActivityItem
-        | GroupHiscoresBossItem
-        | GroupHiscoresSkillItem
-        | GroupHiscoresComputedMetricItem
-    )
+    data: t.Union[
+        GroupHiscoresActivityItem,
+        GroupHiscoresBossItem,
+        GroupHiscoresSkillItem,
+        GroupHiscoresComputedMetricItem,
+    ]
     """The data for this hiscores entry."""
 
 
@@ -317,22 +318,22 @@ class ComputedMetricLeader(BaseModel):
 class MetricLeaders(BaseModel):
     """The leaders for each metric in a group."""
 
-    skills: dict[enums.Skills, SkillLeader]
+    skills: t.Dict[enums.Skills, SkillLeader]
     """A mapping of [`Skills`][wom.Skills] keys to [`SkillLeader`]
     [wom.SkillLeader] values.
     """
 
-    bosses: dict[enums.Bosses, BossLeader]
+    bosses: t.Dict[enums.Bosses, BossLeader]
     """A mapping of [`Bosses`][wom.Bosses] keys to [`BossLeader`]
     [wom.BossLeader] values.
     """
 
-    activities: dict[enums.Activities, ActivityLeader]
+    activities: t.Dict[enums.Activities, ActivityLeader]
     """A mapping of [`Activities`][wom.Activities] keys to [`ActivityLeader`]
     [wom.ActivityLeader] values.
     """
 
-    computed: dict[enums.ComputedMetrics, ComputedMetricLeader]
+    computed: t.Dict[enums.ComputedMetrics, ComputedMetricLeader]
     """A mapping of [`ComputedMetrics`][wom.ComputedMetrics] keys to
     [`ComputedMetricLeader`][wom.ComputedMetricLeader] values.
     """

--- a/wom/models/names/models.py
+++ b/wom/models/names/models.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 
+import typing as t
 from datetime import datetime
 
 import attrs
@@ -50,7 +51,7 @@ class NameChange(BaseModel):
     status: NameChangeStatus
     """The [`status`][wom.NameChangeStatus] of the name change."""
 
-    resolved_at: datetime | None
+    resolved_at: t.Optional[datetime]
     """The date the name change was approved or denied."""
 
     updated_at: datetime

--- a/wom/models/players/models.py
+++ b/wom/models/players/models.py
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 
+import typing as t
 from datetime import datetime
 
 import attrs
@@ -128,22 +129,22 @@ class ComputedMetric(BaseModel):
 class SnapshotData(BaseModel):
     """The data associated with this snapshot."""
 
-    skills: dict[enums.Skills, Skill]
+    skills: t.Dict[enums.Skills, Skill]
     """A mapping of [`Skills`][wom.Skills] keys to [`Skill`][wom.Skill] values
     from this snapshot.
     """
 
-    bosses: dict[enums.Bosses, Boss]
+    bosses: t.Dict[enums.Bosses, Boss]
     """A mapping of [`Bosses`][wom.Bosses] keys to [`Boss`][wom.Boss] values
     from this snapshot.
     """
 
-    activities: dict[enums.Activities, Activity]
+    activities: t.Dict[enums.Activities, Activity]
     """A mapping of [`Activities`][wom.Activities] keys to [`Activity`]
     [wom.Activity] values from this snapshot.
     """
 
-    computed: dict[enums.ComputedMetrics, ComputedMetric]
+    computed: t.Dict[enums.ComputedMetrics, ComputedMetric]
     """A mapping of [`ComputedMetrics`][wom.ComputedMetrics] keys to
     [`ComputedMetric`][wom.ComputedMetric] values from this snapshot.
     """
@@ -159,7 +160,7 @@ class Snapshot(BaseModel):
     player_id: int
     """The unique ID of the player for this snapshot."""
 
-    imported_at: datetime | None
+    imported_at: t.Optional[datetime]
     """The date the snapshot was imported, if it was."""
 
     data: SnapshotData
@@ -188,7 +189,7 @@ class Player(BaseModel):
     build: PlayerBuild
     """The [`PlayerBuild`][wom.PlayerBuild] for this player."""
 
-    country: Country | None
+    country: t.Optional[Country]
     """The players [`Country`][wom.Country] country of origin, if they
     have one set.
     """
@@ -217,10 +218,10 @@ class Player(BaseModel):
     updated_at: datetime
     """The date the player was last updated with WOM."""
 
-    last_changed_at: datetime | None
+    last_changed_at: t.Optional[datetime]
     """The date of the players last change (xp gain, boss kc, etc)."""
 
-    last_imported_at: datetime | None
+    last_imported_at: t.Optional[datetime]
     """The date of the last player history import."""
 
 
@@ -234,7 +235,7 @@ class PlayerDetail(BaseModel):
     combat_level: int
     """The players combat level."""
 
-    latest_snapshot: Snapshot | None
+    latest_snapshot: t.Optional[Snapshot]
     """The latest snapshot for the player, if there is one."""
 
 
@@ -273,7 +274,7 @@ class Achievement(BaseModel):
     created_at: datetime
     """The date the achievement was achieved."""
 
-    accuracy: int | None
+    accuracy: t.Optional[int]
     """The margin of error for the achievements creation date.
 
     !!! note
@@ -305,12 +306,12 @@ class AchievementProgress(BaseModel):
     threshold: int
     """The threshold for this achievement."""
 
-    created_at: datetime | None
+    created_at: t.Optional[datetime]
     """The date the achievement was achieved, or `None` if it has not
     been achieved.
     """
 
-    accuracy: int | None
+    accuracy: t.Optional[int]
     """The margin of error for the achievements creation date.
 
     !!! note
@@ -428,22 +429,22 @@ class ComputedGains(BaseModel):
 class PlayerGainsData(BaseModel):
     """Contains all the player gains data."""
 
-    skills: dict[enums.Skills, SkillGains]
+    skills: t.Dict[enums.Skills, SkillGains]
     """A mapping of [`Skills`][wom.Skills] keys to [`SkillGains`]
     [wom.SkillGains] values.
     """
 
-    bosses: dict[enums.Bosses, BossGains]
+    bosses: t.Dict[enums.Bosses, BossGains]
     """A mapping of [`Bosses`][wom.Bosses] keys to [`BossGains`]
     [wom.BossGains] values.
     """
 
-    activities: dict[enums.Activities, ActivityGains]
+    activities: t.Dict[enums.Activities, ActivityGains]
     """A mapping of [`Activities`][wom.Activities] keys to [`ActivityGains`]
     [wom.ActivityGains] values.
     """
 
-    computed: dict[enums.ComputedMetrics, ComputedGains]
+    computed: t.Dict[enums.ComputedMetrics, ComputedGains]
     """A mapping of [`ComputedMetrics`][wom.ComputedMetrics] keys to
     [`ComputedGains`] [wom.ComputedGains] values.
     """

--- a/wom/routes.py
+++ b/wom/routes.py
@@ -42,7 +42,7 @@ class CompiledRoute:
     def __init__(self, route: Route, uri: str) -> None:
         self._uri = uri
         self._route = route
-        self._params: dict[str, str | int] = {}
+        self._params: t.Dict[str, t.Union[str, int]] = {}
 
     @property
     def route(self) -> Route:
@@ -64,11 +64,11 @@ class CompiledRoute:
         return self.route.method
 
     @property
-    def params(self) -> dict[str, str | int]:
+    def params(self) -> t.Dict[str, t.Union[str, int]]:
         """The query params for the route."""
         return self._params
 
-    def with_params(self, params: dict[str, t.Any]) -> CompiledRoute:
+    def with_params(self, params: t.Dict[str, t.Any]) -> CompiledRoute:
         """Adds additional query params to this compiled route.
 
         Args:
@@ -92,7 +92,7 @@ class Route:
     uri: str
     """The request uri."""
 
-    def compile(self, *args: str | int) -> CompiledRoute:
+    def compile(self, *args: t.Union[str, int]) -> CompiledRoute:
         """Turn this route into a compiled route.
 
         Args:

--- a/wom/services/base.py
+++ b/wom/services/base.py
@@ -47,8 +47,8 @@ class BaseService(abc.ABC):
     def __init__(self, http_service: HttpService, serializer: serializer.Serializer) -> None:
         self._http = http_service
         self._serializer = serializer
-        self._dict = dict[str, t.Any]
-        self._list = list[dict[str, t.Any]]
+        self._dict = t.Dict[str, t.Any]
+        self._list = t.List[t.Dict[str, t.Any]]
 
-    def _generate_map(self, **kwargs: t.Any) -> dict[str, t.Any]:
+    def _generate_map(self, **kwargs: t.Any) -> t.Dict[str, t.Any]:
         return {k: v for k, v in kwargs.items() if v is not None}

--- a/wom/services/competitions.py
+++ b/wom/services/competitions.py
@@ -45,13 +45,13 @@ class CompetitionService(BaseService):
     async def search_competitions(
         self,
         *,
-        title: str | None = None,
-        type: models.CompetitionType | None = None,
-        status: models.CompetitionStatus | None = None,
-        metric: enums.Metric | None = None,
-        limit: int | None = None,
-        offset: int | None = None,
-    ) -> ResultT[list[models.Competition]]:
+        title: t.Optional[str] = None,
+        type: t.Optional[models.CompetitionType] = None,
+        status: t.Optional[models.CompetitionStatus] = None,
+        metric: t.Optional[enums.Metric] = None,
+        limit: t.Optional[int] = None,
+        offset: t.Optional[int] = None,
+    ) -> ResultT[t.List[models.Competition]]:
         """Searches for competitions with the given criteria.
 
         Keyword Args:
@@ -113,7 +113,7 @@ class CompetitionService(BaseService):
         return result.Ok([self._serializer.deserialize_competition(c) for c in data])
 
     async def get_details(
-        self, id: int, *, metric: enums.Metric | None = None
+        self, id: int, *, metric: t.Optional[enums.Metric] = None
     ) -> ResultT[models.CompetitionDetail]:
         """Gets details for the given competition.
 
@@ -154,8 +154,8 @@ class CompetitionService(BaseService):
         return result.Ok(self._serializer.deserialize_competition_details(data))
 
     async def get_top_participant_history(
-        self, id: int, *, metric: enums.Metric | None = None
-    ) -> ResultT[list[models.Top5ProgressResult]]:
+        self, id: int, *, metric: t.Optional[enums.Metric] = None
+    ) -> ResultT[t.List[models.Top5ProgressResult]]:
         """Gets details for the players with the top 5 progress in the
         competition.
 
@@ -201,10 +201,10 @@ class CompetitionService(BaseService):
         starts_at: datetime,
         ends_at: datetime,
         *,
-        group_id: int | None = None,
-        group_verification_code: str | None = None,
-        teams: list[models.Team] | None = None,
-        participants: list[str] | None = None,
+        group_id: t.Optional[int] = None,
+        group_verification_code: t.Optional[str] = None,
+        teams: t.Optional[t.List[models.Team]] = None,
+        participants: t.Optional[t.List[str]] = None,
     ) -> ResultT[models.CompetitionWithParticipations]:
         """Creates a new competition.
 
@@ -301,12 +301,12 @@ class CompetitionService(BaseService):
         id: int,
         verification_code: str,
         *,
-        title: str | None = None,
-        metric: enums.Metric | None = None,
-        starts_at: datetime | None = None,
-        ends_at: datetime | None = None,
-        teams: list[models.Team] | None = None,
-        participants: list[str] | None = None,
+        title: t.Optional[str] = None,
+        metric: t.Optional[enums.Metric] = None,
+        starts_at: t.Optional[datetime] = None,
+        ends_at: t.Optional[datetime] = None,
+        teams: t.Optional[t.List[models.Team]] = None,
+        participants: t.Optional[t.List[str]] = None,
     ) -> ResultT[models.CompetitionWithParticipations]:
         """Edits an existing competition.
 

--- a/wom/services/deltas.py
+++ b/wom/services/deltas.py
@@ -46,10 +46,10 @@ class DeltaService(BaseService):
         metric: enums.Metric,
         period: enums.Period,
         *,
-        player_type: models.PlayerType | None = None,
-        player_build: models.PlayerBuild | None = None,
-        country: models.Country | None = None,
-    ) -> ResultT[list[models.DeltaLeaderboardEntry]]:
+        player_type: t.Optional[models.PlayerType] = None,
+        player_build: t.Optional[models.PlayerBuild] = None,
+        country: t.Optional[models.Country] = None,
+    ) -> ResultT[t.List[models.DeltaLeaderboardEntry]]:
         """Gets the top global delta leaderboard for a specific
         metric and period.
 

--- a/wom/services/efficiency.py
+++ b/wom/services/efficiency.py
@@ -45,11 +45,11 @@ class EfficiencyService(BaseService):
         self,
         metric: enums.ComputedMetrics = enums.ComputedMetrics.Ehp,
         *,
-        player_type: models.PlayerType | None = None,
-        player_build: models.PlayerBuild | None = None,
-        country: models.Country | None = None,
+        player_type: t.Optional[models.PlayerType] = None,
+        player_build: t.Optional[models.PlayerBuild] = None,
+        country: t.Optional[models.Country] = None,
         both: bool = False,
-    ) -> ResultT[list[models.Player]]:
+    ) -> ResultT[t.List[models.Player]]:
         """Gets the top global efficiency leaderboard.
 
         Args:

--- a/wom/services/groups.py
+++ b/wom/services/groups.py
@@ -45,12 +45,15 @@ class GroupService(BaseService):
 
     def _prepare_member_fragments(
         self, members: t.Iterable[models.GroupMemberFragment]
-    ) -> tuple[dict[str, t.Any], ...]:
+    ) -> tuple[t.Dict[str, t.Any], ...]:
         return tuple({k: str(v) for k, v in m.to_dict().items() if v} for m in members)
 
     async def search_groups(
-        self, name: str | None = None, limit: int | None = None, offset: int | None = None
-    ) -> ResultT[list[models.Group]]:
+        self,
+        name: t.Optional[str] = None,
+        limit: t.Optional[int] = None,
+        offset: t.Optional[int] = None,
+    ) -> ResultT[t.List[models.Group]]:
         """Searches for groups that at least partially match the given
         name.
 
@@ -117,9 +120,9 @@ class GroupService(BaseService):
         self,
         name: str,
         *members: models.GroupMemberFragment,
-        clan_chat: str | None = None,
-        description: str | None = None,
-        homeworld: int | None = None,
+        clan_chat: t.Optional[str] = None,
+        description: t.Optional[str] = None,
+        homeworld: t.Optional[int] = None,
     ) -> ResultT[models.GroupDetail]:
         """Creates a new group.
 
@@ -182,11 +185,11 @@ class GroupService(BaseService):
         id: int,
         verification_code: str,
         *,
-        name: str | None = None,
-        members: t.Iterable[models.GroupMemberFragment] | None = None,
-        clan_chat: str | None = None,
-        description: str | None = None,
-        homeworld: int | None = None,
+        name: t.Optional[str] = None,
+        members: t.Optional[t.Iterable[models.GroupMemberFragment]] = None,
+        clan_chat: t.Optional[str] = None,
+        description: t.Optional[str] = None,
+        homeworld: t.Optional[int] = None,
     ) -> ResultT[models.GroupDetail]:
         """Edits an existing group.
 
@@ -489,8 +492,8 @@ class GroupService(BaseService):
         return result.Err(data)
 
     async def get_competitions(
-        self, id: int, *, limit: int | None = None, offset: int | None = None
-    ) -> ResultT[list[models.Competition]]:
+        self, id: int, *, limit: t.Optional[int] = None, offset: t.Optional[int] = None
+    ) -> ResultT[t.List[models.Competition]]:
         """Gets competitions for a given group.
 
         Args:
@@ -531,12 +534,12 @@ class GroupService(BaseService):
         id: int,
         metric: enums.Metric,
         *,
-        period: enums.Period | None = None,
-        start_date: datetime | None = None,
-        end_date: datetime | None = None,
-        limit: int | None = None,
-        offset: int | None = None,
-    ) -> ResultT[list[models.DeltaLeaderboardEntry]]:
+        period: t.Optional[enums.Period] = None,
+        start_date: t.Optional[datetime] = None,
+        end_date: t.Optional[datetime] = None,
+        limit: t.Optional[int] = None,
+        offset: t.Optional[int] = None,
+    ) -> ResultT[t.List[models.DeltaLeaderboardEntry]]:
         """Gets the gains for a group over a particular time frame.
 
         Args:
@@ -602,9 +605,9 @@ class GroupService(BaseService):
         self,
         id: int,
         *,
-        limit: int | None = None,
-        offset: int | None = None,
-    ) -> ResultT[list[models.Achievement]]:
+        limit: t.Optional[int] = None,
+        offset: t.Optional[int] = None,
+    ) -> ResultT[t.List[models.Achievement]]:
         """Gets the achievements for the group.
 
         Args:
@@ -646,9 +649,9 @@ class GroupService(BaseService):
         metric: enums.Metric,
         period: enums.Period,
         *,
-        limit: int | None = None,
-        offset: int | None = None,
-    ) -> ResultT[list[models.RecordLeaderboardEntry]]:
+        limit: t.Optional[int] = None,
+        offset: t.Optional[int] = None,
+    ) -> ResultT[t.List[models.RecordLeaderboardEntry]]:
         """Gets the records held by players in the group.
 
         Args:
@@ -701,9 +704,9 @@ class GroupService(BaseService):
         id: int,
         metric: enums.Metric,
         *,
-        limit: int | None = None,
-        offset: int | None = None,
-    ) -> ResultT[list[models.GroupHiscoresEntry]]:
+        limit: t.Optional[int] = None,
+        offset: t.Optional[int] = None,
+    ) -> ResultT[t.List[models.GroupHiscoresEntry]]:
         """Gets the hiscores for the group.
 
         Args:
@@ -744,8 +747,8 @@ class GroupService(BaseService):
         return result.Ok([self._serializer.deserialize_group_hiscores_entry(h) for h in data])
 
     async def get_name_changes(
-        self, id: int, *, limit: int | None = None, offset: int | None = None
-    ) -> ResultT[list[models.NameChange]]:
+        self, id: int, *, limit: t.Optional[int] = None, offset: t.Optional[int] = None
+    ) -> ResultT[t.List[models.NameChange]]:
         """Gets the past name changes for the group.
 
         Args:

--- a/wom/services/http.py
+++ b/wom/services/http.py
@@ -51,9 +51,9 @@ class HttpService:
 
     def __init__(
         self,
-        api_key: str | None,
-        user_agent: str | None,
-        api_base_url: str | None,
+        api_key: t.Optional[str],
+        user_agent: t.Optional[str],
+        api_base_url: t.Optional[str],
     ) -> None:
         self._headers = {
             "x-user-agent": (
@@ -153,7 +153,7 @@ class HttpService:
         route: routes.CompiledRoute,
         _: t.Type[T],
         *,
-        payload: dict[str, t.Any] | None = None,
+        payload: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> T | models.HttpErrorResponse:
         """Fetches the given route.
 

--- a/wom/services/names.py
+++ b/wom/services/names.py
@@ -42,12 +42,12 @@ class NameChangeService(BaseService):
 
     async def search_name_changes(
         self,
-        username: str | None = None,
+        username: t.Optional[str] = None,
         *,
-        status: models.NameChangeStatus | None = None,
-        limit: int | None = None,
-        offset: int | None = None,
-    ) -> ResultT[list[models.NameChange]]:
+        status: t.Optional[models.NameChangeStatus] = None,
+        limit: t.Optional[int] = None,
+        offset: t.Optional[int] = None,
+    ) -> ResultT[t.List[models.NameChange]]:
         """Searches for name changes.
 
         Args:

--- a/wom/services/players.py
+++ b/wom/services/players.py
@@ -43,8 +43,8 @@ class PlayerService(BaseService):
     __slots__ = ()
 
     async def search_players(
-        self, username: str, *, limit: int | None = None, offset: int | None = None
-    ) -> ResultT[list[models.Player]]:
+        self, username: str, *, limit: t.Optional[int] = None, offset: t.Optional[int] = None
+    ) -> ResultT[t.List[models.Player]]:
         """Searches for a player by partial username.
 
         Args:
@@ -200,7 +200,7 @@ class PlayerService(BaseService):
 
         return result.Ok(self._serializer.deserialize_player_details(data))
 
-    async def get_achievements(self, username: str) -> ResultT[list[models.Achievement]]:
+    async def get_achievements(self, username: str) -> ResultT[t.List[models.Achievement]]:
         """Gets the achievements for a given player.
 
         Args:
@@ -232,7 +232,7 @@ class PlayerService(BaseService):
 
     async def get_achievement_progress(
         self, username: str
-    ) -> ResultT[list[models.PlayerAchievementProgress]]:
+    ) -> ResultT[t.List[models.PlayerAchievementProgress]]:
         """Gets the progress towards achievements for a given player.
 
         Args:
@@ -268,10 +268,10 @@ class PlayerService(BaseService):
         self,
         username: str,
         *,
-        limit: int | None = None,
-        offset: int | None = None,
-        status: models.CompetitionStatus | None = None,
-    ) -> ResultT[list[models.PlayerParticipation]]:
+        limit: t.Optional[int] = None,
+        offset: t.Optional[int] = None,
+        status: t.Optional[models.CompetitionStatus] = None,
+    ) -> ResultT[t.List[models.PlayerParticipation]]:
         """Gets the competition participations for a given player.
 
         Args:
@@ -320,7 +320,7 @@ class PlayerService(BaseService):
         self,
         username: str,
         status: models.CompetitionStatus,
-    ) -> ResultT[list[models.PlayerCompetitionStanding]]:
+    ) -> ResultT[t.List[models.PlayerCompetitionStanding]]:
         """Gets the competition standings for a given player.
 
         Args:
@@ -358,8 +358,8 @@ class PlayerService(BaseService):
         )
 
     async def get_group_memberships(
-        self, username: str, *, limit: int | None = None, offset: int | None = None
-    ) -> ResultT[list[models.PlayerMembership]]:
+        self, username: str, *, limit: t.Optional[int] = None, offset: t.Optional[int] = None
+    ) -> ResultT[t.List[models.PlayerMembership]]:
         """Gets the group memberships for the given player.
 
         Args:
@@ -403,9 +403,9 @@ class PlayerService(BaseService):
         self,
         username: str,
         *,
-        period: enums.Period | None = None,
-        start_date: datetime | None = None,
-        end_date: datetime | None = None,
+        period: t.Optional[enums.Period] = None,
+        start_date: t.Optional[datetime] = None,
+        end_date: t.Optional[datetime] = None,
     ) -> ResultT[models.PlayerGains]:
         """Gets the gains made by this player over the given time span.
 
@@ -462,9 +462,9 @@ class PlayerService(BaseService):
         self,
         username: str,
         *,
-        period: enums.Period | None = None,
-        metric: enums.Metric | None = None,
-    ) -> ResultT[list[models.Record]]:
+        period: t.Optional[enums.Period] = None,
+        metric: t.Optional[enums.Metric] = None,
+    ) -> ResultT[t.List[models.Record]]:
         """Gets the records held by this player.
 
         Args:
@@ -511,10 +511,10 @@ class PlayerService(BaseService):
         self,
         username: str,
         *,
-        period: enums.Period | None = None,
-        start_date: datetime | None = None,
-        end_date: datetime | None = None,
-    ) -> ResultT[list[models.Snapshot]]:
+        period: t.Optional[enums.Period] = None,
+        start_date: t.Optional[datetime] = None,
+        end_date: t.Optional[datetime] = None,
+    ) -> ResultT[t.List[models.Snapshot]]:
         """Gets the snapshots for the player.
 
         Args:
@@ -566,7 +566,7 @@ class PlayerService(BaseService):
 
         return result.Ok([self._serializer.deserialize_snapshot(s) for s in data])
 
-    async def get_name_changes(self, username: str) -> ResultT[list[models.NameChange]]:
+    async def get_name_changes(self, username: str) -> ResultT[t.List[models.NameChange]]:
         """Gets the name changes for the player.
 
         Args:

--- a/wom/services/records.py
+++ b/wom/services/records.py
@@ -46,10 +46,10 @@ class RecordService(BaseService):
         metric: enums.Metric,
         period: enums.Period,
         *,
-        player_type: models.PlayerType | None = None,
-        player_build: models.PlayerBuild | None = None,
-        country: models.Country | None = None,
-    ) -> ResultT[list[models.RecordLeaderboardEntry]]:
+        player_type: t.Optional[models.PlayerType] = None,
+        player_build: t.Optional[models.PlayerBuild] = None,
+        country: t.Optional[models.Country] = None,
+    ) -> ResultT[t.List[models.RecordLeaderboardEntry]]:
         """Gets the global record leaderboards.
 
         Args:


### PR DESCRIPTION
This PR replaces usage of 3.9 and 3.10 only type hints as compatibility was broken pretty badly.

Closes #15