### PR TITLE
Add "Banned" PlayerStatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.4.2 (Jun 2023)
+
+## Additions
+
+- Add `Banned` player status.
+- Add helpful error message if new enum variants are not yet added to the lib.
+
+---
+
 # v0.4.1 (May 2023)
 
 ## Breaking Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wom.py"
-version = "0.4.1"
+version = "0.4.2"
 description = "An asynchronous wrapper for the Wise Old Man API."
 authors = ["Jonxslays"]
 license = "MIT"

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -36,14 +36,14 @@ def test_from_str_none() -> None:
     with pytest.raises(ValueError) as e:
         _ = enums.Period.from_str(None)  # type: ignore
 
-    assert e.exconly() == "ValueError: None is not a valid Period"
+    assert e.exconly().startswith("ValueError: None is not a valid Period variant.")
 
 
 def test_from_str_invalid() -> None:
     with pytest.raises(ValueError) as e:
         _ = enums.Period.from_str("fake")  # type: ignore
 
-    assert e.exconly() == "ValueError: 'fake' is not a valid Period"
+    assert e.exconly().startswith("ValueError: 'fake' is not a valid Period variant.")
 
 
 def test_from_str_maybe() -> None:
@@ -80,17 +80,17 @@ def test_metric_child_from_str() -> None:
 
 
 def test_metric_from_str_invalid() -> None:
-    with pytest.raises(RuntimeError) as e:
+    with pytest.raises(ValueError) as e:
         _ = enums.Metric.from_str("hmmm")
 
-    assert e.exconly() == "RuntimeError: No <enum 'Metric'> variant for 'hmmm'."
+    assert e.exconly().startswith("ValueError: 'hmmm' is not a valid Metric variant.")
 
 
 def test_metric_from_str_none() -> None:
-    with pytest.raises(RuntimeError) as e:
+    with pytest.raises(ValueError) as e:
         _ = enums.Metric.from_str(None)  # type: ignore
 
-    assert e.exconly() == "RuntimeError: No <enum 'Metric'> variant for None."
+    assert e.exconly().startswith("ValueError: None is not a valid Metric variant.")
 
 
 def test_metric_from_str_maybe() -> None:

--- a/wom/__init__.py
+++ b/wom/__init__.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from typing import Final
 
 __packagename__: Final[str] = "wom.py"
-__version__: Final[str] = "0.4.1"
+__version__: Final[str] = "0.4.2"
 __author__: Final[str] = "Jonxslays"
 __copyright__: Final[str] = "2023-present Jonxslays"
 __description__: Final[str] = "An asynchronous wrapper for the Wise Old Man API."

--- a/wom/enums.py
+++ b/wom/enums.py
@@ -111,13 +111,11 @@ class Metric(BaseEnum):
     @classmethod
     def from_str_maybe(cls: t.Type[T], value: str) -> t.Optional[T]:
         if cls is not Metric:
-            print("Trying ")
             return super().from_str_maybe(value)  # pyright: ignore
 
         children = {Skills, Activities, Bosses, ComputedMetrics}
 
         for child in children:
-            print("Trying", child)
             try:
                 return child(value)  # type: ignore
             except ValueError:

--- a/wom/enums.py
+++ b/wom/enums.py
@@ -55,7 +55,13 @@ class BaseEnum(Enum):
         Returns:
             The generated enum.
         """
-        return cls(value)
+        try:
+            return cls(value)
+        except ValueError as e:
+            raise ValueError(
+                f"{e} variant. Please report this issue on github at "
+                "https://github.com/Jonxslays/wom.py/issues/new"
+            ) from None
 
     @classmethod
     def from_str_maybe(cls: t.Type[T], value: str) -> t.Optional[T]:
@@ -87,7 +93,7 @@ class Metric(BaseEnum):
     @classmethod
     def from_str(cls: t.Type[T], value: str) -> T:
         if cls is not Metric:
-            return cls(value)
+            return super().from_str(value)
 
         children = {Skills, Activities, Bosses, ComputedMetrics}
 
@@ -97,16 +103,21 @@ class Metric(BaseEnum):
             except ValueError:
                 continue
 
-        raise RuntimeError(f"No {cls} variant for {value!r}.")
+        raise ValueError(
+            f"{value!r} is not a valid {cls.__name__} variant. "
+            "Please report this issue on github at https://github.com/Jonxslays/wom.py/issues/new"
+        )
 
     @classmethod
     def from_str_maybe(cls: t.Type[T], value: str) -> t.Optional[T]:
         if cls is not Metric:
-            return super(Metric, cls).from_str_maybe(value)  # pyright: ignore
+            print("Trying ")
+            return super().from_str_maybe(value)  # pyright: ignore
 
         children = {Skills, Activities, Bosses, ComputedMetrics}
 
         for child in children:
+            print("Trying", child)
             try:
                 return child(value)  # type: ignore
             except ValueError:

--- a/wom/models/players/enums.py
+++ b/wom/models/players/enums.py
@@ -61,6 +61,7 @@ class PlayerStatus(BaseEnum):
     Unranked = "unranked"
     Flagged = "flagged"
     Archived = "archived"
+    Banned = "banned"
 
 
 class AchievementMeasure(BaseEnum):


### PR DESCRIPTION
This PR adds the banned player status, updates associated tests and also adds a helpful error message when new enum variants are added to WOM but are not yet implemented in wom.py.

Closes #20 