### PR TITLE
Add rank property to snapshot timeline entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.8.1 (Nov 2023)
+
+## Additions
+
+- Add `rank` property to `SnapshotTimelineEntry`.
+
+---
+
 # v0.8.0 (Oct 2023)
 
 ## Additions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wom.py"
-version = "0.8.0"
+version = "0.8.1"
 description = "An asynchronous wrapper for the Wise Old Man API."
 authors = ["Jonxslays"]
 license = "MIT"

--- a/wom/__init__.py
+++ b/wom/__init__.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from typing import Final
 
 __packagename__: Final[str] = "wom.py"
-__version__: Final[str] = "0.8.0"
+__version__: Final[str] = "0.8.1"
 __author__: Final[str] = "Jonxslays"
 __copyright__: Final[str] = "2023-present Jonxslays"
 __description__: Final[str] = "An asynchronous wrapper for the Wise Old Man API."

--- a/wom/models/players/models.py
+++ b/wom/models/players/models.py
@@ -470,7 +470,12 @@ class SnapshotTimelineEntry(BaseModel):
     """An entry representing a point in time of a players gains."""
 
     value: int
-    """The total xp gained since the last timeline entry."""
+    """The players value for a specific metric, at a specific point in
+    time."""
+
+    rank: int
+    """The players rank for a specific metric, at a specific point in
+    time."""
 
     date: datetime
     """The date this timeline entry was recorded."""

--- a/wom/serializer.py
+++ b/wom/serializer.py
@@ -1125,7 +1125,7 @@ class Serializer:
         """
         entry = models.SnapshotTimelineEntry()
         entry.date = self._dt_from_iso(data["date"])
-        entry.value = data["value"]
+        self._set_attrs(entry, data, "value", "rank")
         return entry
 
     @serializer_guard


### PR DESCRIPTION
This PR adds the `rank` property to `SnapshotTimelineEntry`.

Originating from: wise-old-man/wise-old-man#1307
