### PR TITLE
Added missing spaces, fixed example code.

### DIFF
--- a/wom/services/groups.py
+++ b/wom/services/groups.py
@@ -129,13 +129,13 @@ class GroupService(BaseService):
         Args:
             name: The name for the group.
 
-            *members: The optional members to add to the group.
+            *members: The optional members to add to the group, as GroupMemberFragment objects.
 
         Keyword Args:
             clan_chat: The optional clan chat for the group. Defaults to
                 `None`.
 
-            description: The optional group description.Defaults to
+            description: The optional group description. Defaults to
                 `None`.
 
             homeworld: The optional homeworld for the group. Defaults to
@@ -155,8 +155,8 @@ class GroupService(BaseService):
 
             await client.groups.create_group(
                 "My new group",
-                "Jonxslays",
-                "Zezima",
+                wom.models.GroupMemberFragment("Jonxslays", wom.models.GroupRole.Owner),
+                wom.models.GroupMemberFragment("Faabvk"),
                 description="The most epic group."
             )
             ```
@@ -208,7 +208,7 @@ class GroupService(BaseService):
             clan_chat: The optional new clan chat for the group.
                 Defaults to `None`.
 
-            description: The optional new group description.Defaults to
+            description: The optional new group description. Defaults to
                 `None`.
 
             homeworld: The optional new homeworld for the group.
@@ -236,7 +236,10 @@ class GroupService(BaseService):
                 123,
                 "111-111-111",
                 name="My new group name",
-                members=["Jonxslays"],
+                members=[
+                    wom.models.GroupMemberFragment("Jonxslays", wom.models.GroupRole.Owner),
+                    wom.models.GroupMemberFragment("Faabvk", None)
+                ],
                 description="Some new description."
             )
             ```
@@ -325,11 +328,11 @@ class GroupService(BaseService):
             await client.groups.add_members(
                 123,
                 "111-111-111",
-                wom.GroupMemberFragment(
+                wom.models.GroupMemberFragment(
                     "Jonxslays", wom.GroupRole.Administrator
                 ),
-                wom.GroupMemberFragment("Zezima"),
-                wom.GroupMemberFragment("Psikoi"),
+                wom.models.GroupMemberFragment("Zezima"),
+                wom.models.GroupMemberFragment("Psikoi"),
             )
             ```
         """

--- a/wom/services/groups.py
+++ b/wom/services/groups.py
@@ -328,7 +328,7 @@ class GroupService(BaseService):
             await client.groups.add_members(
                 123,
                 "111-111-111",
-                wom.models.GroupMemberFragment(
+                wom.GroupMemberFragment(
                     "Jonxslays", wom.GroupRole.Administrator
                 ),
                 wom.GroupMemberFragment("Zezima"),

--- a/wom/services/groups.py
+++ b/wom/services/groups.py
@@ -129,7 +129,7 @@ class GroupService(BaseService):
         Args:
             name: The name for the group.
 
-            *members: The optional members to add to the group, as GroupMemberFragment objects.
+            *members: The optional members to add to the group.
 
         Keyword Args:
             clan_chat: The optional clan chat for the group. Defaults to
@@ -155,8 +155,8 @@ class GroupService(BaseService):
 
             await client.groups.create_group(
                 "My new group",
-                wom.models.GroupMemberFragment("Jonxslays", wom.models.GroupRole.Owner),
-                wom.models.GroupMemberFragment("Faabvk"),
+                wom.GroupMemberFragment("Jonxslays", wom.GroupRole.Owner),
+                wom.GroupMemberFragment("Faabvk"),
                 description="The most epic group."
             )
             ```
@@ -237,8 +237,8 @@ class GroupService(BaseService):
                 "111-111-111",
                 name="My new group name",
                 members=[
-                    wom.models.GroupMemberFragment("Jonxslays", wom.models.GroupRole.Owner),
-                    wom.models.GroupMemberFragment("Faabvk", None)
+                    wom.GroupMemberFragment("Jonxslays", wom.GroupRole.Owner),
+                    wom.GroupMemberFragment("Faabvk")
                 ],
                 description="Some new description."
             )
@@ -331,8 +331,8 @@ class GroupService(BaseService):
                 wom.models.GroupMemberFragment(
                     "Jonxslays", wom.GroupRole.Administrator
                 ),
-                wom.models.GroupMemberFragment("Zezima"),
-                wom.models.GroupMemberFragment("Psikoi"),
+                wom.GroupMemberFragment("Zezima"),
+                wom.GroupMemberFragment("Psikoi"),
             )
             ```
         """


### PR DESCRIPTION
Several fixes to the documentation as requested in #35 

- Added missing spaces to the explanation of the description argument in create_group() and edit_group()
- Fixed example code
    - create_group() and edit_group(): Made it so GroupMemberFragment objects are passed instead of strings, which would not work.
    - add_members(): GroupMemberFragments were already used here, but they weren't declared correctly when compared to the way wom.py is imported

This PR is to just fix the issues, intending to have another PR to actually allow strings to be passed as group members.