### PR TITLE
Add support for choosing enum variants at random

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Unreleased (Nov 2023)
+
+## Additions
+
+- Add `at_random` method to `BaseEnum` for picking an enum value at random.
+
+## Changes
+
+- Update examples in `GroupService` that work with `GroupMemberFragment`.
+
+---
+
 # v0.8.1 (Nov 2023)
 
 ## Additions

--- a/wom/enums.py
+++ b/wom/enums.py
@@ -23,6 +23,7 @@
 
 from __future__ import annotations
 
+import random
 import typing as t
 from enum import Enum
 
@@ -78,6 +79,14 @@ class BaseEnum(Enum):
             return cls(value)
         except ValueError:
             return None
+
+    @classmethod
+    def at_random(cls: t.Type[T]) -> T:
+        """Generates a random variant of this enum.
+
+        Returns:
+            The randomly generated enum."""
+        return random.choice(tuple(cls))
 
 
 class Metric(BaseEnum):


### PR DESCRIPTION
This PR adds a new `at_random()` method onto `BaseEnum`. This allows for choosing a random variant of any of its child classes.

i.e. `Skills.at_random()`, `Bosses.at_random()`, etc...

Resolves #41 