### PR TITLE
Make levels and social links non-optional

### DIFF
--- a/wom/models/competitions/models.py
+++ b/wom/models/competitions/models.py
@@ -186,10 +186,10 @@ class CompetitionParticipationDetail(BaseModel):
     made.
     """
 
-    levels: t.Optional[CompetitionProgress]
-    """The optional [`CompetitionProgress`][wom.CompetitionProgress] as it
-    relates the number of overall levels gained. Can be `None` if this is not a
-    skilling competition, or the player is unranked in the skill."""
+    levels: CompetitionProgress
+    """The [`CompetitionProgress`][wom.CompetitionProgress] as it relates to
+    the number of levels gained. Only contains useful information for skilling
+    competitions."""
 
 
 @attrs.define(init=False)

--- a/wom/models/groups/models.py
+++ b/wom/models/groups/models.py
@@ -113,8 +113,8 @@ class GroupDetail(BaseModel):
     memberships: t.List[GroupMembership]
     """A list of [`GroupMemberships`][wom.GroupMembership]."""
 
-    social_links: t.Optional[SocialLinks]
-    """The social links for this group, if any."""
+    social_links: SocialLinks
+    """The social links for this group."""
 
     verification_code: t.Optional[str]
     """The optional verification code for the group.

--- a/wom/serializer.py
+++ b/wom/serializer.py
@@ -694,12 +694,7 @@ class Serializer:
         details.verification_code = None
         details.group = self.deserialize_group(data)
         details.memberships = [self.deserialize_group_membership(m) for m in data["memberships"]]
-
-        if links := data.get("socialLinks", None):
-            details.social_links = self.deserialize_social_links(links)
-        else:
-            details.social_links = links
-
+        details.social_links = self.deserialize_social_links(data["links"])
         return details
 
     @serializer_guard
@@ -957,12 +952,7 @@ class Serializer:
         details = models.CompetitionParticipationDetail()
         details.participation = self.deserialize_competition_participation(data)
         details.progress = self.deserialize_competition_progress(data["progress"])
-
-        if levels := data.get("levels", None):
-            details.levels = self.deserialize_competition_progress(levels)
-        else:
-            details.levels = levels
-
+        details.levels = self.deserialize_competition_progress(data["levels"])
         return details
 
     @serializer_guard

--- a/wom/services/groups.py
+++ b/wom/services/groups.py
@@ -60,14 +60,6 @@ class GroupService(BaseService):
             else:
                 yield m
 
-    def _parse_social_links(
-        self, links: t.Optional[models.SocialLinks]
-    ) -> t.Optional[dict[str, t.Any]]:
-        if not links:
-            return None
-
-        return {k: v if v else "" for k, v in links.to_dict().items()}
-
     async def search_groups(
         self,
         name: t.Optional[str] = None,
@@ -289,7 +281,7 @@ class GroupService(BaseService):
             description=description,
             verificationCode=verification_code,
             members=self._prepare_member_fragments(members) if members else None,
-            socialLinks=self._parse_social_links(social_links),
+            socialLinks=social_links.to_dict() if social_links else None,
         )
 
         route = routes.EDIT_GROUP.compile(id)


### PR DESCRIPTION
Related to wise-old-man/wise-old-man#1348

social links and levels can no longer be undefined, and thus we can simplify our handling of these properties.

Resolves #49 