### PR TITLE
Remove weakref slots from models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# v0.9.0 (Nov 2023)
 
 ## Additions
 
@@ -12,6 +12,7 @@
 
 - Methods that previously accepted only `GroupMemberFragment` now accept strings as well.
 - Update examples in `GroupService` that work with `GroupMemberFragment`.
+- Remove usage of weakref slots throughout the project, improving memory footprint.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wom.py"
-version = "0.8.1"
+version = "0.9.0"
 description = "An asynchronous wrapper for the Wise Old Man API."
 authors = ["Jonxslays"]
 license = "MIT"
@@ -78,6 +78,9 @@ reportImportCycles = false
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+
+[tool.ruff]
+ignore = ["F405", "F403"]
 
 [build-system]
 requires = ["poetry-core"]

--- a/wom/__init__.py
+++ b/wom/__init__.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from typing import Final
 
 __packagename__: Final[str] = "wom.py"
-__version__: Final[str] = "0.8.1"
+__version__: Final[str] = "0.9.0"
 __author__: Final[str] = "Jonxslays"
 __copyright__: Final[str] = "2023-present Jonxslays"
 __description__: Final[str] = "An asynchronous wrapper for the Wise Old Man API."

--- a/wom/models/base.py
+++ b/wom/models/base.py
@@ -28,7 +28,7 @@ import typing as t
 import attrs
 
 
-@attrs.define
+@attrs.define(weakref_slot=False)
 class BaseModel:
     """The base model all library models inherit from."""
 

--- a/wom/models/competitions/models.py
+++ b/wom/models/competitions/models.py
@@ -51,7 +51,7 @@ __all__ = (
 )
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class CompetitionProgress(BaseModel):
     """Represents progress in a competition."""
 
@@ -65,7 +65,7 @@ class CompetitionProgress(BaseModel):
     """The amount of progress gained in the metric."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class Competition(BaseModel):
     """Represents a competition."""
 
@@ -108,7 +108,7 @@ class Competition(BaseModel):
     """
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class Participation(BaseModel):
     """Represents participation in a competition."""
 
@@ -128,7 +128,7 @@ class Participation(BaseModel):
     """The date this participation was updated."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class CompetitionParticipation(BaseModel):
     """Represents a competition participation."""
 
@@ -141,7 +141,7 @@ class CompetitionParticipation(BaseModel):
     """The [`Player`][wom.Player] that participated in this competition."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class PlayerParticipation(BaseModel):
     """Represents a players participation in a competition."""
 
@@ -154,7 +154,7 @@ class PlayerParticipation(BaseModel):
     """
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class PlayerCompetitionStanding(BaseModel):
     """Represents a players standing in a competition."""
 
@@ -172,7 +172,7 @@ class PlayerCompetitionStanding(BaseModel):
     """The rank in the competition standings."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class CompetitionParticipationDetail(BaseModel):
     """Represents competition participation details."""
 
@@ -192,7 +192,7 @@ class CompetitionParticipationDetail(BaseModel):
     competitions."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class CompetitionDetail(BaseModel):
     """Represents competition details."""
 
@@ -206,7 +206,7 @@ class CompetitionDetail(BaseModel):
     """
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class CompetitionHistoryDataPoint(BaseModel):
     """A competition history data point."""
 
@@ -217,7 +217,7 @@ class CompetitionHistoryDataPoint(BaseModel):
     """The value of the data point."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class Top5ProgressResult(BaseModel):
     """A top 5 progress result for a competition."""
 
@@ -231,7 +231,7 @@ class Top5ProgressResult(BaseModel):
     """
 
 
-@attrs.define
+@attrs.define(weakref_slot=False)
 class Team(BaseModel):
     """Represents a competition team.
 
@@ -258,7 +258,7 @@ class Team(BaseModel):
     """A list of participant usernames on the team."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class CompetitionWithParticipations(BaseModel):
     """Represents a competition with participations."""
 

--- a/wom/models/deltas/models.py
+++ b/wom/models/deltas/models.py
@@ -31,7 +31,7 @@ from ..players import Player
 __all__ = ("DeltaLeaderboardEntry",)
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class DeltaLeaderboardEntry(BaseModel):
     """Represents a leaderboard entry over the given delta."""
 

--- a/wom/models/groups/models.py
+++ b/wom/models/groups/models.py
@@ -59,7 +59,7 @@ __all__ = (
 )
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class Group(BaseModel):
     """Represents a group of players on WOM."""
 
@@ -103,7 +103,7 @@ class Group(BaseModel):
     """The number of members in the group."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class GroupDetail(BaseModel):
     """Represents details about a group."""
 
@@ -125,7 +125,7 @@ class GroupDetail(BaseModel):
     """
 
 
-@attrs.define
+@attrs.define(weakref_slot=False)
 class SocialLinks(BaseModel):
     """A groups social links."""
 
@@ -159,7 +159,7 @@ class SocialLinks(BaseModel):
     """The groups twitch url."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class Membership(BaseModel):
     """Represents a membership in a group."""
 
@@ -179,7 +179,7 @@ class Membership(BaseModel):
     """The date this membership was updated."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class GroupMembership(BaseModel):
     """Represents a group membership."""
 
@@ -190,7 +190,7 @@ class GroupMembership(BaseModel):
     """The [`Membership`][wom.Membership] itself."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class PlayerMembership(BaseModel):
     """Represents a player membership."""
 
@@ -201,7 +201,7 @@ class PlayerMembership(BaseModel):
     """The [`Membership`][wom.Membership] itself."""
 
 
-@attrs.define
+@attrs.define(weakref_slot=False)
 class GroupMemberFragment(BaseModel):
     """Represents a condensed group member.
 
@@ -229,7 +229,7 @@ class GroupMemberFragment(BaseModel):
     """
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class GroupHiscoresEntry(BaseModel):
     """Represents a group hiscores entry."""
 
@@ -245,7 +245,7 @@ class GroupHiscoresEntry(BaseModel):
     """The data for this hiscores entry."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class GroupHiscoresSkillItem(BaseModel):
     """Represents a group hiscores item for skills."""
 
@@ -259,7 +259,7 @@ class GroupHiscoresSkillItem(BaseModel):
     """The experience in the skill."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class GroupHiscoresBossItem(BaseModel):
     """Represents a group hiscores item for bosses."""
 
@@ -270,7 +270,7 @@ class GroupHiscoresBossItem(BaseModel):
     """The number of boss kills."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class GroupHiscoresActivityItem(BaseModel):
     """Represents a group hiscores item for activities."""
 
@@ -281,7 +281,7 @@ class GroupHiscoresActivityItem(BaseModel):
     """The activity score."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class GroupHiscoresComputedMetricItem(BaseModel):
     """Represents a group hiscores item for computed metrics."""
 
@@ -292,7 +292,7 @@ class GroupHiscoresComputedMetricItem(BaseModel):
     """The value of the computed metric."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class SkillLeader(BaseModel):
     """Represents a leader in a particular skill."""
 
@@ -312,7 +312,7 @@ class SkillLeader(BaseModel):
     """The player leading in this metric, or `None` if none do."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class BossLeader(BaseModel):
     """Represents a leader in a particular boss."""
 
@@ -329,7 +329,7 @@ class BossLeader(BaseModel):
     """The player leading in this metric, or `None` if none do."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class ActivityLeader(BaseModel):
     """Represents a leader in a particular activity."""
 
@@ -346,7 +346,7 @@ class ActivityLeader(BaseModel):
     """The player leading in this metric, or `None` if none do."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class ComputedMetricLeader(BaseModel):
     """Represents a leader in a particular computed metric."""
 
@@ -365,7 +365,7 @@ class ComputedMetricLeader(BaseModel):
     """The player leading in this metric, or `None` if none do."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class MetricLeaders(BaseModel):
     """The leaders for each metric in a group."""
 
@@ -390,7 +390,7 @@ class MetricLeaders(BaseModel):
     """
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class GroupStatistics(BaseModel):
     """Represents accumulated group statistics."""
 
@@ -412,7 +412,7 @@ class GroupStatistics(BaseModel):
     """
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class GroupMemberGains(BaseModel):
     """Represents a leaderboard entry over the given delta."""
 
@@ -429,7 +429,7 @@ class GroupMemberGains(BaseModel):
     """The [`Gains`][wom.Gains] for this group member."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class GroupActivity(BaseModel):
     """An activity that occurred in a group."""
 

--- a/wom/models/http.py
+++ b/wom/models/http.py
@@ -30,7 +30,7 @@ from .base import BaseModel
 __all__ = ("HttpErrorResponse", "HttpSuccessResponse")
 
 
-@attrs.define
+@attrs.define(weakref_slot=False)
 class HttpErrorResponse(BaseModel):
     """Indicates something went wrong during the request."""
 
@@ -41,7 +41,7 @@ class HttpErrorResponse(BaseModel):
     """The error message."""
 
 
-@attrs.define
+@attrs.define(weakref_slot=False)
 class HttpSuccessResponse(BaseModel):
     """Indicates a successful HTTP response."""
 

--- a/wom/models/names/models.py
+++ b/wom/models/names/models.py
@@ -40,7 +40,7 @@ __all__ = (
 )
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class NameChangeReviewContext(BaseModel):
     """The review context for a name change that was not approved.
 
@@ -60,7 +60,7 @@ class NameChangeReviewContext(BaseModel):
     """The reason this name change was denied."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class DeniedNameChangeReviewContext(NameChangeReviewContext):  # type: ignore[override]
     """The review context for a name change that was denied."""
 
@@ -78,7 +78,7 @@ class DeniedNameChangeReviewContext(NameChangeReviewContext):  # type: ignore[ov
     """
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class SkippedNameChangeReviewContext(NameChangeReviewContext):  # type: ignore[override]
     """The review context for a name change that was skipped."""
 
@@ -120,7 +120,7 @@ class SkippedNameChangeReviewContext(NameChangeReviewContext):  # type: ignore[o
     """
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class NameChange(BaseModel):
     """Represents a player name change."""
 

--- a/wom/models/players/models.py
+++ b/wom/models/players/models.py
@@ -59,7 +59,7 @@ __all__ = (
 )
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class Skill(BaseModel):
     """Details regarding a particular skill."""
 
@@ -79,7 +79,7 @@ class Skill(BaseModel):
     """The players efficient hours played for the skill."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class Boss(BaseModel):
     """Details regarding a particular boss."""
 
@@ -96,7 +96,7 @@ class Boss(BaseModel):
     """The players efficient hours bossed for the boss."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class Activity(BaseModel):
     """Details regarding a particular activity."""
 
@@ -110,7 +110,7 @@ class Activity(BaseModel):
     """The players score in the activity."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class ComputedMetric(BaseModel):
     """Details regarding a computed metric."""
 
@@ -126,7 +126,7 @@ class ComputedMetric(BaseModel):
     """The value of the computed metric."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class SnapshotData(BaseModel):
     """The data associated with this snapshot."""
 
@@ -151,7 +151,7 @@ class SnapshotData(BaseModel):
     """
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class Snapshot(BaseModel):
     """Represents a player snapshot."""
 
@@ -171,7 +171,7 @@ class Snapshot(BaseModel):
     """The date the snapshot was created."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class Player(BaseModel):
     """Represents a player on WOM."""
 
@@ -226,7 +226,7 @@ class Player(BaseModel):
     """The date of the last player history import."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class PlayerDetail(BaseModel):
     """Represents details about a player."""
 
@@ -240,7 +240,7 @@ class PlayerDetail(BaseModel):
     """The latest snapshot for the player, if there is one."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class AssertPlayerType(BaseModel):
     """Represents a player type that has been asserted."""
 
@@ -251,7 +251,7 @@ class AssertPlayerType(BaseModel):
     """Whether or not the player type changed."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class Achievement(BaseModel):
     """Represents an achievement made by a player."""
 
@@ -286,7 +286,7 @@ class Achievement(BaseModel):
     """
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class AchievementProgress(BaseModel):
     """Represents progress made toward an achievement."""
 
@@ -323,7 +323,7 @@ class AchievementProgress(BaseModel):
     """
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class PlayerAchievementProgress(BaseModel):
     """Represents a players progress toward an achievement."""
 
@@ -347,7 +347,7 @@ class PlayerAchievementProgress(BaseModel):
     """
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class Gains(BaseModel):
     """Represents gains made by a player."""
 
@@ -361,7 +361,7 @@ class Gains(BaseModel):
     """The ending amount."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class SkillGains(BaseModel):
     """Represents skill gains made by a player."""
 
@@ -381,7 +381,7 @@ class SkillGains(BaseModel):
     """The level [`Gains`][wom.Gains]."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class BossGains(BaseModel):
     """Represents boss gains made by a player."""
 
@@ -398,7 +398,7 @@ class BossGains(BaseModel):
     """The boss kill [`Gains`][wom.Gains]."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class ActivityGains(BaseModel):
     """Represents activity gains made by a player."""
 
@@ -412,7 +412,7 @@ class ActivityGains(BaseModel):
     """The score [`Gains`][wom.Gains]."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class ComputedGains(BaseModel):
     """Represents computed gains made by a player."""
 
@@ -426,7 +426,7 @@ class ComputedGains(BaseModel):
     """The value [`Gains`][wom.Gains]."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class PlayerGainsData(BaseModel):
     """Contains all the player gains data."""
 
@@ -451,7 +451,7 @@ class PlayerGainsData(BaseModel):
     """
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class PlayerGains(BaseModel):
     """Gains made by a player."""
 
@@ -465,7 +465,7 @@ class PlayerGains(BaseModel):
     """The [`PlayerGainsData`][wom.PlayerGainsData] for the player."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class SnapshotTimelineEntry(BaseModel):
     """An entry representing a point in time of a players gains."""
 

--- a/wom/models/records/models.py
+++ b/wom/models/records/models.py
@@ -33,7 +33,7 @@ from ..players import Player
 __all__ = ("Record", "RecordLeaderboardEntry")
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class Record(BaseModel):
     """Represents a record held by a player."""
 
@@ -56,7 +56,7 @@ class Record(BaseModel):
     """The records creation/modification date."""
 
 
-@attrs.define(init=False)
+@attrs.define(init=False, weakref_slot=False)
 class RecordLeaderboardEntry(BaseModel):
     """Represents a player's record leaderboard entry."""
 

--- a/wom/routes.py
+++ b/wom/routes.py
@@ -83,7 +83,7 @@ class CompiledRoute:
         return self
 
 
-@attrs.define
+@attrs.define(weakref_slot=False)
 class Route:
     """A route that has not been compiled yet."""
 


### PR DESCRIPTION
This PR sets `weakref_slot=False` on all models decorated by `@attrs.define`.

Bumps project version in preparation for the next release.

Resolves #46 