### PR TITLE
Change clanChat to an optional field

### DIFF
--- a/wom/models/groups/models.py
+++ b/wom/models/groups/models.py
@@ -70,8 +70,8 @@ class Group(BaseModel):
     name: str
     """The groups name."""
 
-    clan_chat: str
-    """The clan chat for this group."""
+    clan_chat: t.Optional[str]
+    """The groups optional clan chat."""
 
     description: t.Optional[str]
     """The groups optional description."""


### PR DESCRIPTION
Changed clanChat to optional, since this is not a required field in some WiseOldMan groups.
This may be an intended change, reflecting WiseOldMan's updates to require ClanChat associations to groups; however due to the existence of many groups that do not have attached clan chats, this is a problem that can be reproduced by using groups.get_details(any id without an associated clanchat).

Based on my testing, simply updating this to t.Optional resolves the issue.

 See: https://api.wiseoldman.net/v2/groups/3896