### PR TITLE
Add 'GB_ENG' country enum value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v3.0.1 (May 2026)
+
+## Additions
+
+- Added new 'GB_ENG' country enum value.
+
+---
+
 # v3.0.0 (February 2026)
 
 ## Breaking Changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wom.py"
-version = "3.0.0"
+version = "3.0.1"
 description = "An asynchronous wrapper for the Wise Old Man API."
 authors = ["Jonxslays"]
 license = "MIT"

--- a/wom/__init__.py
+++ b/wom/__init__.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from typing import Final
 
 __packagename__: Final[str] = "wom.py"
-__version__: Final[str] = "3.0.0"
+__version__: Final[str] = "3.0.1"
 __author__: Final[str] = "Jonxslays"
 __copyright__: Final[str] = "2023-present Jonxslays"
 __description__: Final[str] = "An asynchronous wrapper for the Wise Old Man API."

--- a/wom/models/players/enums.py
+++ b/wom/models/players/enums.py
@@ -155,6 +155,7 @@ class Country(BaseEnum):
     Fr = "FR"
     Ga = "GA"
     Gb = "GB"
+    Gb_Eng = "GB_ENG"
     Gb_Nir = "GB_NIR"
     Gb_Sct = "GB_SCT"
     Gb_Wls = "GB_WLS"


### PR DESCRIPTION
Adds the 'GB_ENG' enum value to the countries enum used by wom.py.

WOM added this country enum value as part of the following PR: https://github.com/wise-old-man/wise-old-man/pull/1744