### PR TITLE
Address #81: graceful Unknown enum fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,18 @@
-# v3.2.1 (Unreleased)
+# v3.3.0 (Unreleased)
 
 ## Additions
 
 - Add optional `HttpErrorResponse.code` field capturing the machine-readable
   error code returned by the WOM API (defaults to `None` when absent).
+- Every `BaseEnum` subclass now defines an `Unknown` variant. Unrecognized
+  values received from the API decode to `Unknown` (via `BaseEnum._missing_`)
+  instead of raising, and a warning is emitted to `stderr`. `Unknown` is skipped
+  when iterating an enum (via `BaseEnumMeta`), so `at_random()` never returns it.
 
 ## Changes
 
+- Bump the minimum `msgspec` version to `>=0.21.0`, which is required to decode
+  enums that use a custom metaclass.
 - Migrate the build and dependency management from Poetry to
   [uv](https://docs.astral.sh/uv/) (`pyproject.toml` moved to PEP 621 with the
   hatchling backend, and CI/release workflows now use uv). No changes to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "wom.py"
-version = "3.2.1"
+version = "3.3.0"
 description = "An asynchronous wrapper for the Wise Old Man API."
 authors = [{ name = "Jonxslays" }]
 license = { text = "MIT" }
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = ["aiohttp>3.8.1", "msgspec>=0.20.0"]
+dependencies = ["aiohttp>3.8.1", "msgspec>=0.21.0"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: AsyncIO",

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -21,9 +21,20 @@
 
 from __future__ import annotations
 
+import typing as t
 from unittest import mock
 
+import pytest
+
 import wom
+
+
+def _base_enum_subclasses() -> t.List[t.Type[wom.BaseEnum]]:
+    return [
+        obj
+        for obj in (getattr(wom, name) for name in wom.__all__)
+        if isinstance(obj, type) and issubclass(obj, wom.BaseEnum) and obj is not wom.BaseEnum
+    ]
 
 
 def test_str() -> None:
@@ -53,3 +64,25 @@ def test_hash() -> None:
 def test_at_random(choice: mock.MagicMock) -> None:
     _ = wom.Metric.at_random()
     choice.assert_called_once_with(tuple(wom.Metric))
+
+
+def test_all_enums_have_unknown() -> None:
+    for enum in _base_enum_subclasses():
+        assert hasattr(enum, "Unknown"), f"{enum.__name__} is missing an Unknown variant"
+        assert enum.Unknown.value == "unknown"
+
+
+def test_iter_excludes_unknown() -> None:
+    for enum in _base_enum_subclasses():
+        assert enum.Unknown not in tuple(enum)
+
+
+def test_missing_returns_unknown(capsys: pytest.CaptureFixture[str]) -> None:
+    assert wom.Metric("new_fake_metric") is wom.Metric.Unknown
+    assert wom.Period("fake") is wom.Period.Unknown
+    assert wom.Metric.Attack.value == "attack"
+    assert wom.Metric.Unknown != wom.Metric.Zulrah
+
+    captured = capsys.readouterr()
+    assert "not a valid Metric variant" in captured.err
+    assert "not a valid Period variant" in captured.err

--- a/uv.lock
+++ b/uv.lock
@@ -2165,7 +2165,7 @@ wheels = [
 
 [[package]]
 name = "wom-py"
-version = "3.2.1"
+version = "3.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -2194,7 +2194,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">3.8.1" },
-    { name = "msgspec", specifier = ">=0.20.0" },
+    { name = "msgspec", specifier = ">=0.21.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/wom/__init__.py
+++ b/wom/__init__.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 from typing import Final
 
 __packagename__: Final[str] = "wom.py"
-__version__: Final[str] = "3.2.1"
+__version__: Final[str] = "3.3.0"
 __author__: Final[str] = "Jonxslays"
 __copyright__: Final[str] = "2023-present Jonxslays"
 __description__: Final[str] = "An asynchronous wrapper for the Wise Old Man API."

--- a/wom/enums.py
+++ b/wom/enums.py
@@ -24,8 +24,10 @@
 from __future__ import annotations
 
 import random
+import sys
 import typing as t
 from enum import Enum
+from enum import EnumMeta
 
 T = t.TypeVar("T", bound="BaseEnum")
 
@@ -40,7 +42,16 @@ __all__ = (
 )
 
 
-class BaseEnum(Enum):
+class BaseEnumMeta(EnumMeta):
+    """Metaclass for [`BaseEnum`][wom.BaseEnum]."""
+
+    def __iter__(cls) -> t.Iterator[t.Any]:
+        """Iterates over the enum's members, skipping the `Unknown` variant."""
+        members: t.Iterable[t.Any] = super().__iter__()
+        return (member for member in members if member.value != "unknown")
+
+
+class BaseEnum(Enum, metaclass=BaseEnumMeta):
     """The base enum all library enums inherit from."""
 
     def __str__(self) -> str:
@@ -59,6 +70,15 @@ class BaseEnum(Enum):
         return hash(self.value)
 
     @classmethod
+    def _missing_(cls, value: object) -> BaseEnum:
+        print(
+            f"{value!r} is not a valid {cls.__name__} variant. "
+            "Please report this issue on github at https://github.com/Jonxslays/wom.py/issues/new",
+            file=sys.stderr,
+        )
+        return cls.Unknown  # type: ignore[attr-defined,no-any-return]
+
+    @classmethod
     def at_random(cls: t.Type[T]) -> T:
         """Generates a random variant of this enum.
 
@@ -67,7 +87,7 @@ class BaseEnum(Enum):
         T
             The randomly generated enum.
         """
-        return random.choice(tuple(cls))
+        return t.cast(T, random.choice(tuple(cls)))
 
 
 class Period(BaseEnum):
@@ -78,6 +98,7 @@ class Period(BaseEnum):
     Week = "week"
     Month = "month"
     Year = "year"
+    Unknown = "unknown"
 
 
 class Metric(BaseEnum):
@@ -206,6 +227,9 @@ class Metric(BaseEnum):
     # Computed Metrics
     Ehp = "ehp"
     Ehb = "ehb"
+
+    # Unknown
+    Unknown = "unknown"
 
 
 ComputedMetrics: t.FrozenSet[Metric] = frozenset({Metric.Ehp, Metric.Ehb})

--- a/wom/models/competitions/enums.py
+++ b/wom/models/competitions/enums.py
@@ -33,6 +33,7 @@ class CompetitionType(BaseEnum):
 
     Classic = "classic"
     Team = "team"
+    Unknown = "unknown"
 
 
 class CompetitionStatus(BaseEnum):
@@ -41,6 +42,7 @@ class CompetitionStatus(BaseEnum):
     Upcoming = "upcoming"
     Ongoing = "ongoing"
     Finished = "finished"
+    Unknown = "unknown"
 
 
 class CompetitionCSVTableType(BaseEnum):
@@ -49,3 +51,4 @@ class CompetitionCSVTableType(BaseEnum):
     Participants = "participants"
     Team = "team"
     Teams = "teams"
+    Unknown = "unknown"

--- a/wom/models/groups/enums.py
+++ b/wom/models/groups/enums.py
@@ -32,6 +32,7 @@ class GroupActivityType(BaseEnum):
     ChangedRole = "changed_role"
     Joined = "joined"
     Left = "left"
+    Unknown = "unknown"
 
 
 class GroupRole(BaseEnum):
@@ -306,3 +307,4 @@ class GroupRole(BaseEnum):
     Zarosian = "zarosian"
     Zealot = "zealot"
     Zenyte = "zenyte"
+    Unknown = "unknown"

--- a/wom/models/names/enums.py
+++ b/wom/models/names/enums.py
@@ -32,6 +32,7 @@ class NameChangeStatus(BaseEnum):
     Pending = "pending"
     Approved = "approved"
     Denied = "denied"
+    Unknown = "unknown"
 
 
 class NameChangeReviewReason(BaseEnum):
@@ -42,3 +43,4 @@ class NameChangeReviewReason(BaseEnum):
     TransitionTooLong = "transition_period_too_long"
     ExcessiveGains = "excessive_gains"
     TotalLevelTooLow = "total_level_too_low"
+    Unknown = "unknown"

--- a/wom/models/players/enums.py
+++ b/wom/models/players/enums.py
@@ -35,12 +35,12 @@ __all__ = (
 class PlayerType(BaseEnum):
     """Different types of players."""
 
-    Unknown = "unknown"
     Regular = "regular"
     Ironman = "ironman"
     Hardcore = "hardcore"
     Ultimate = "ultimate"
     FreshStart = "fresh_start"
+    Unknown = "unknown"
 
 
 class PlayerBuild(BaseEnum):
@@ -53,6 +53,7 @@ class PlayerBuild(BaseEnum):
     Def1 = "def1"
     Hp10 = "hp10"
     F2pLvl3 = "f2p_lvl3"
+    Unknown = "unknown"
 
 
 class PlayerStatus(BaseEnum):
@@ -63,6 +64,7 @@ class PlayerStatus(BaseEnum):
     Flagged = "flagged"
     Archived = "archived"
     Banned = "banned"
+    Unknown = "unknown"
 
 
 class AchievementMeasure(BaseEnum):
@@ -73,6 +75,7 @@ class AchievementMeasure(BaseEnum):
     Kills = "kills"
     Score = "score"
     Value = "value"
+    Unknown = "unknown"
 
 
 class Country(BaseEnum):
@@ -331,3 +334,4 @@ class Country(BaseEnum):
     Za = "ZA"
     Zm = "ZM"
     Zw = "ZW"
+    Unknown = "unknown"


### PR DESCRIPTION
Resolves #81. Supersedes #82.

Refined re-implementation of @Sharpienero's original work in #82 (their `missing-enum-fix` branch), rebased onto current master. Thanks @Sharpienero for the original fix.

- Every `BaseEnum` subclass declares an `Unknown` variant (type-checker visible)
- `BaseEnum._missing_` decodes unrecognized API values to `Unknown` + warns on stderr
- `BaseEnumMeta` hides `Unknown` from iteration (so `at_random()` skips it)
- Bumps `msgspec>=0.21.0` (required to decode enums with a custom metaclass)
- Bumps version to 3.3.0, updates CHANGELOG, adds tests

All checks pass: mypy + pyright (strict), 157 tests, black, isort, flake8, alls.