### PR TITLE
Fix NameChangeReviewContext fractional diff fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@
   that service methods never raise on API errors. A bare-message endpoint that
   returns a 2xx without the expected `{"message": ...}` envelope is likewise
   reported as success rather than raising.
+- `NameChangeReviewContext` now types its fractional diff fields as floats:
+  `hours_diff`, `ehp_diff`, and `ehb_diff` are `Optional[float]`, and
+  `negative_gains` values are `float`. Previously these were `int`, causing
+  `get_name_change_details` to raise a `msgspec.ValidationError` when the API
+  returned a fractional `hoursDiff` (e.g. on a denied
+  `transition_period_too_long` change).
 
 ## Changes
 

--- a/tests/services/test_behavior.py
+++ b/tests/services/test_behavior.py
@@ -319,6 +319,39 @@ async def test_get_name_change_details_omits_data_when_absent() -> None:
     assert detail.data is None
 
 
+async def test_get_name_change_details_decodes_fractional_review_context() -> None:
+    # A denied ``transition_period_too_long`` change carries a review context
+    # whose ``hoursDiff`` is fractional; it must decode as a float, not raise.
+    body = b"""{
+        "nameChange": {
+            "id": 9,
+            "playerId": 42,
+            "oldName": "old guy",
+            "newName": "new guy",
+            "status": "denied",
+            "reviewContext": {
+                "reason": "transition_period_too_long",
+                "hoursDiff": 12.5,
+                "maxHoursDiff": 72
+            },
+            "resolvedAt": "2024-02-02T00:00:00.000Z",
+            "updatedAt": "2024-02-02T00:00:00.000Z",
+            "createdAt": "2024-01-01T00:00:00.000Z"
+        }
+    }"""
+    service, _ = _service(wom.NameChangeService, body)
+
+    result = await service.get_name_change_details(9)
+
+    assert result.is_ok
+    detail = result.unwrap()
+    context = detail.name_change.review_context
+    assert context is not None
+    assert context.reason is wom.NameChangeReviewReason.TransitionTooLong
+    assert context.hours_diff == 12.5
+    assert context.max_hours_diff == 72
+
+
 async def test_bulk_submit_name_changes_decodes_result_and_posts_array() -> None:
     body = b'{"nameChangesSubmitted": 2, "message": "Successfully submitted 2/2 name changes."}'
     service, http = _service(wom.NameChangeService, body)

--- a/wom/models/names/models.py
+++ b/wom/models/names/models.py
@@ -51,7 +51,7 @@ class NameChangeReviewContext(BaseModel):
     # public on the name change endpoints and if we do
     # determine how to handle it in a cleaner way.
 
-    negative_gains: t.Optional[t.Dict[enums.Metric, int]] = None
+    negative_gains: t.Optional[t.Dict[enums.Metric, float]] = None
     """The negative gains that were observed, if there were any. Only populated
     when the reason is `NegativeGains`.
     """
@@ -61,17 +61,17 @@ class NameChangeReviewContext(BaseModel):
     reason is `TransitionTooLong`.
     """
 
-    hours_diff: t.Optional[int] = None
+    hours_diff: t.Optional[float] = None
     """The actual number of hours in the transition period. Only populated when
     reason is `TransitionTooLong` or `ExcessiveGains`.
     """
 
-    ehp_diff: t.Optional[int] = None
+    ehp_diff: t.Optional[float] = None
     """The number difference between the old and new names ehp. Only populated
     when the reason is `ExcessiveGains`.
     """
 
-    ehb_diff: t.Optional[int] = None
+    ehb_diff: t.Optional[float] = None
     """The number difference between the old and new names ehb. Only populated
     when the reason is `ExcessiveGains`.
     """


### PR DESCRIPTION
## Summary

`client.names.get_name_change_details(...)` raised a `msgspec.ValidationError` while decoding a denied name change:

```
msgspec.ValidationError: Expected `int | null`, got `float` - at `$.nameChange.reviewContext.hoursDiff`
```

The WOM API returns a **fractional** `hoursDiff` in a name change's `reviewContext` (confirmed against live `transition_period_too_long` changes), but `NameChangeReviewContext` typed its diff fields as `int`.

## Fix

Type the fractional diff fields as `float`:

- `hours_diff`, `ehp_diff`, `ehb_diff` → `Optional[float]`
- `negative_gains` values → `float` (aligning with the sibling `NameChangeData.negative_gains`, whose `ehp`/`ehb` metrics are floats)

`max_hours_diff` and the total-level fields stay `int` (confirmed integers in the live API). Since `float` decodes ints fine, this is strictly more permissive.

## Testing

- Added `test_get_name_change_details_decodes_fractional_review_context` covering a denied `transition_period_too_long` context with a fractional `hoursDiff`.
- `nox` passes (tests, types, formatting, imports, licensing, alls).