### PR TITLE
Default Snapshot.imported_at to None for live snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
   that service methods never raise on API errors. A bare-message endpoint that
   returns a 2xx without the expected `{"message": ...}` envelope is likewise
   reported as success rather than raising.
+- `Snapshot.imported_at` now defaults to `None`, so a live (never-imported)
+  snapshot that omits the `importedAt` key entirely decodes instead of raising a
+  `msgspec.ValidationError`. This previously broke `get_name_change_details`
+  (and any snapshot-returning endpoint) whenever the API returned a fresh
+  hiscores snapshot.
 
 ## Changes
 

--- a/tests/services/test_behavior.py
+++ b/tests/services/test_behavior.py
@@ -293,6 +293,63 @@ async def test_get_name_change_details_decodes_nested_data() -> None:
     assert route.uri == "/names/7"
 
 
+async def test_snapshot_decodes_without_imported_at_key() -> None:
+    # A live (never-imported) snapshot omits ``importedAt`` entirely rather than
+    # sending it as null; ``imported_at`` must default to None, not raise.
+    snapshot_no_imported = """{
+        "id": -1,
+        "playerId": 42,
+        "createdAt": "2024-01-01T00:00:00.000Z",
+        "data": {
+            "skills": {},
+            "bosses": {},
+            "activities": {},
+            "computed": {}
+        }
+    }"""
+    body = (
+        """{
+        "nameChange": {
+            "id": 10,
+            "playerId": 42,
+            "oldName": "old guy",
+            "newName": "new guy",
+            "status": "pending",
+            "reviewContext": null,
+            "resolvedAt": null,
+            "updatedAt": "2024-01-02T03:04:05.000Z",
+            "createdAt": "2024-01-01T00:00:00.000Z"
+        },
+        "data": {
+            "isNewOnHiscores": true,
+            "isOldOnHiscores": false,
+            "isNewTracked": false,
+            "hasNegativeGains": false,
+            "negativeGains": null,
+            "timeDiff": 3600000,
+            "hoursDiff": 1.5,
+            "ehpDiff": 2.5,
+            "ehbDiff": 0.0,
+            "oldStats": """
+        + _SNAPSHOT_JSON
+        + ""","newStats": """
+        + snapshot_no_imported
+        + """}
+    }"""
+    ).encode()
+    service, _ = _service(wom.NameChangeService, body)
+
+    result = await service.get_name_change_details(10)
+
+    assert result.is_ok
+    detail = result.unwrap()
+    assert detail.data is not None
+    # Present-but-null on the old snapshot, absent on the new one: both None.
+    assert detail.data.old_stats.imported_at is None
+    assert detail.data.new_stats is not None
+    assert detail.data.new_stats.imported_at is None
+
+
 async def test_get_name_change_details_omits_data_when_absent() -> None:
     # An already-resolved change comes back with just ``{ nameChange }`` and no
     # ``data`` key; the optional field must default to None, not raise.

--- a/wom/models/players/models.py
+++ b/wom/models/players/models.py
@@ -145,14 +145,16 @@ class Snapshot(BaseModel):
     player_id: int
     """The unique ID of the player for this snapshot."""
 
-    imported_at: t.Optional[datetime]
-    """The date the snapshot was imported, if it was."""
-
     data: SnapshotData
     """The [`SnapshotData`][wom.SnapshotData] for the snapshot."""
 
     created_at: datetime
     """The date the snapshot was created."""
+
+    imported_at: t.Optional[datetime] = None
+    """The date the snapshot was imported, if it was. `None` when the key is
+    absent (a live snapshot) as well as when it is present but null.
+    """
 
 
 class Player(BaseModel):


### PR DESCRIPTION
## Summary

`client.names.get_name_change_details(...)` raised a `msgspec.ValidationError` decoding a pending change:

```
msgspec.ValidationError: Object missing required field `importedAt` - at `$.data.newStats`
```

A live (never-imported) player snapshot omits the `importedAt` key **entirely** (confirmed against the live API — `newStats` has no `importedAt`, while an imported `oldStats` sends it as `null`). `Snapshot.imported_at` was `Optional[datetime]` with no default, so msgspec still required the key to be present.

## Fix

Give `Snapshot.imported_at` a `None` default so an absent key decodes to `None` (matching the existing present-but-null behavior). The field moves below `data`/`created_at` because msgspec requires defaulted fields to follow non-defaulted ones — nothing constructs `Snapshot` positionally, so this is safe.

This fixes `get_name_change_details` and any other snapshot-returning endpoint that can surface a fresh hiscores snapshot.

## Testing

- Added `test_snapshot_decodes_without_imported_at_key` covering a detail whose `newStats` omits `importedAt` (and `oldStats` sends it as null) — both decode to `imported_at is None`.
- `nox` passes (tests, types, formatting, imports, licensing, alls).