### PR TITLE
Fix get_name_change_details decoding of real API responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@
   that service methods never raise on API errors. A bare-message endpoint that
   returns a 2xx without the expected `{"message": ...}` envelope is likewise
   reported as success rather than raising.
+- `NameChangeReviewContext` now types its fractional diff fields as floats:
+  `hours_diff`, `ehp_diff`, and `ehb_diff` are `Optional[float]`, and
+  `negative_gains` values are `float`. Previously these were `int`, causing
+  `get_name_change_details` to raise a `msgspec.ValidationError` when the API
+  returned a fractional `hoursDiff` (e.g. on a denied
+  `transition_period_too_long` change).
 
 ## Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@
   `get_name_change_details` to raise a `msgspec.ValidationError` when the API
   returned a fractional `hoursDiff` (e.g. on a denied
   `transition_period_too_long` change).
+- `Snapshot.imported_at` now defaults to `None`, so a live (never-imported)
+  snapshot that omits the `importedAt` key entirely decodes instead of raising a
+  `msgspec.ValidationError`. This previously broke `get_name_change_details`
+  (and any snapshot-returning endpoint) whenever the API returned a fresh
+  hiscores snapshot.
 
 ## Changes
 

--- a/tests/services/test_behavior.py
+++ b/tests/services/test_behavior.py
@@ -319,6 +319,39 @@ async def test_get_name_change_details_omits_data_when_absent() -> None:
     assert detail.data is None
 
 
+async def test_get_name_change_details_decodes_fractional_review_context() -> None:
+    # A denied ``transition_period_too_long`` change carries a review context
+    # whose ``hoursDiff`` is fractional; it must decode as a float, not raise.
+    body = b"""{
+        "nameChange": {
+            "id": 9,
+            "playerId": 42,
+            "oldName": "old guy",
+            "newName": "new guy",
+            "status": "denied",
+            "reviewContext": {
+                "reason": "transition_period_too_long",
+                "hoursDiff": 12.5,
+                "maxHoursDiff": 72
+            },
+            "resolvedAt": "2024-02-02T00:00:00.000Z",
+            "updatedAt": "2024-02-02T00:00:00.000Z",
+            "createdAt": "2024-01-01T00:00:00.000Z"
+        }
+    }"""
+    service, _ = _service(wom.NameChangeService, body)
+
+    result = await service.get_name_change_details(9)
+
+    assert result.is_ok
+    detail = result.unwrap()
+    context = detail.name_change.review_context
+    assert context is not None
+    assert context.reason is wom.NameChangeReviewReason.TransitionTooLong
+    assert context.hours_diff == 12.5
+    assert context.max_hours_diff == 72
+
+
 async def test_bulk_submit_name_changes_decodes_result_and_posts_array() -> None:
     body = b'{"nameChangesSubmitted": 2, "message": "Successfully submitted 2/2 name changes."}'
     service, http = _service(wom.NameChangeService, body)

--- a/tests/services/test_behavior.py
+++ b/tests/services/test_behavior.py
@@ -293,6 +293,63 @@ async def test_get_name_change_details_decodes_nested_data() -> None:
     assert route.uri == "/names/7"
 
 
+async def test_snapshot_decodes_without_imported_at_key() -> None:
+    # A live (never-imported) snapshot omits ``importedAt`` entirely rather than
+    # sending it as null; ``imported_at`` must default to None, not raise.
+    snapshot_no_imported = """{
+        "id": -1,
+        "playerId": 42,
+        "createdAt": "2024-01-01T00:00:00.000Z",
+        "data": {
+            "skills": {},
+            "bosses": {},
+            "activities": {},
+            "computed": {}
+        }
+    }"""
+    body = (
+        """{
+        "nameChange": {
+            "id": 10,
+            "playerId": 42,
+            "oldName": "old guy",
+            "newName": "new guy",
+            "status": "pending",
+            "reviewContext": null,
+            "resolvedAt": null,
+            "updatedAt": "2024-01-02T03:04:05.000Z",
+            "createdAt": "2024-01-01T00:00:00.000Z"
+        },
+        "data": {
+            "isNewOnHiscores": true,
+            "isOldOnHiscores": false,
+            "isNewTracked": false,
+            "hasNegativeGains": false,
+            "negativeGains": null,
+            "timeDiff": 3600000,
+            "hoursDiff": 1.5,
+            "ehpDiff": 2.5,
+            "ehbDiff": 0.0,
+            "oldStats": """
+        + _SNAPSHOT_JSON
+        + ""","newStats": """
+        + snapshot_no_imported
+        + """}
+    }"""
+    ).encode()
+    service, _ = _service(wom.NameChangeService, body)
+
+    result = await service.get_name_change_details(10)
+
+    assert result.is_ok
+    detail = result.unwrap()
+    assert detail.data is not None
+    # Present-but-null on the old snapshot, absent on the new one: both None.
+    assert detail.data.old_stats.imported_at is None
+    assert detail.data.new_stats is not None
+    assert detail.data.new_stats.imported_at is None
+
+
 async def test_get_name_change_details_omits_data_when_absent() -> None:
     # An already-resolved change comes back with just ``{ nameChange }`` and no
     # ``data`` key; the optional field must default to None, not raise.

--- a/wom/models/names/models.py
+++ b/wom/models/names/models.py
@@ -51,7 +51,7 @@ class NameChangeReviewContext(BaseModel):
     # public on the name change endpoints and if we do
     # determine how to handle it in a cleaner way.
 
-    negative_gains: t.Optional[t.Dict[enums.Metric, int]] = None
+    negative_gains: t.Optional[t.Dict[enums.Metric, float]] = None
     """The negative gains that were observed, if there were any. Only populated
     when the reason is `NegativeGains`.
     """
@@ -61,17 +61,17 @@ class NameChangeReviewContext(BaseModel):
     reason is `TransitionTooLong`.
     """
 
-    hours_diff: t.Optional[int] = None
+    hours_diff: t.Optional[float] = None
     """The actual number of hours in the transition period. Only populated when
     reason is `TransitionTooLong` or `ExcessiveGains`.
     """
 
-    ehp_diff: t.Optional[int] = None
+    ehp_diff: t.Optional[float] = None
     """The number difference between the old and new names ehp. Only populated
     when the reason is `ExcessiveGains`.
     """
 
-    ehb_diff: t.Optional[int] = None
+    ehb_diff: t.Optional[float] = None
     """The number difference between the old and new names ehb. Only populated
     when the reason is `ExcessiveGains`.
     """

--- a/wom/models/players/models.py
+++ b/wom/models/players/models.py
@@ -145,14 +145,16 @@ class Snapshot(BaseModel):
     player_id: int
     """The unique ID of the player for this snapshot."""
 
-    imported_at: t.Optional[datetime]
-    """The date the snapshot was imported, if it was."""
-
     data: SnapshotData
     """The [`SnapshotData`][wom.SnapshotData] for the snapshot."""
 
     created_at: datetime
     """The date the snapshot was created."""
+
+    imported_at: t.Optional[datetime] = None
+    """The date the snapshot was imported, if it was. `None` when the key is
+    absent (a live snapshot) as well as when it is present but null.
+    """
 
 
 class Player(BaseModel):


### PR DESCRIPTION
## Summary

`client.names.get_name_change_details(...)` raised `msgspec.ValidationError` on real responses due to two model/API mismatches. This branch fixes both.

### 1. `NameChangeReviewContext` fractional diff fields

```
msgspec.ValidationError: Expected `int | null`, got `float` - at `$.nameChange.reviewContext.hoursDiff`
```

The API returns a **fractional** `hoursDiff` in a name change's `reviewContext` (confirmed against a live `transition_period_too_long` change: `hoursDiff` is a float, `maxHoursDiff` an int). Type the fractional fields as `float`:

- `hours_diff`, `ehp_diff`, `ehb_diff` → `Optional[float]`
- `negative_gains` values → `float` (aligning with the sibling `NameChangeData.negative_gains`, whose `ehp`/`ehb` metrics are floats)

`max_hours_diff` and the total-level fields stay `int`. Since `float` decodes ints fine, this is strictly more permissive.

### 2. `Snapshot.imported_at` on live snapshots

```
msgspec.ValidationError: Object missing required field `importedAt` - at `$.data.newStats`
```

A live (never-imported) snapshot omits the `importedAt` key **entirely** (confirmed: `newStats` has no `importedAt`, while an imported `oldStats` sends it as `null`). `imported_at` was `Optional[datetime]` with no default, so msgspec still required the key. Give it a `None` default (moved below `data`/`created_at`, since msgspec requires defaulted fields last — nothing constructs `Snapshot` positionally). This also fixes every other snapshot-returning endpoint that can surface a fresh snapshot.

## Testing

- `test_get_name_change_details_decodes_fractional_review_context` — denied `transition_period_too_long` context with a fractional `hoursDiff`.
- `test_snapshot_decodes_without_imported_at_key` — a detail whose `newStats` omits `importedAt` (and `oldStats` sends it as null) both decode to `imported_at is None`.
- Full `nox` passes (tests, types, formatting, imports, licensing, alls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)