### PR TITLE
Set v3.3.0 release date in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v3.3.0 (Unreleased)
+# v3.3.0 (Aug 2026)
 
 ## Additions
 


### PR DESCRIPTION
Stamps the v3.3.0 changelog heading with its release date (`# v3.3.0 (Aug 2026)`) ahead of tagging the release.

Package version is already `3.3.0` in both `pyproject.toml` and `wom/__init__.py`; this only finalizes the changelog date.