### PR TITLE
Set up Codecov for coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,11 @@ jobs:
         run: |
           uv sync
           uv run nox -s tests
-          mv .coverage .coverage.${{ matrix.os }}.${{ matrix.python-version }}
 
-      - name: Upload coverage to action
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:
-          name: coverage-${{ matrix.os }}.${{ matrix.python-version }}
-          path: .coverage.${{ matrix.os }}.${{ matrix.python-version }}
-          retention-days: 1
-          if-no-files-found: error
-          include-hidden-files: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lint-and-format:
     name: Lint
@@ -63,39 +58,3 @@ jobs:
         run: |
           uv sync
           uv run nox -s ${{ matrix.session }}
-
-  # upload-coverage:
-  #   if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-  #   name: Upload coverage
-  #   needs: test
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Checkout code
-  #       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-  #     - name: Set up Python
-  #       uses: actions/setup-python@v3
-  #       with:
-  #         python-version: "3.10"
-
-  #     - name: Install dependencies
-  #       run: python -m pip install coverage
-
-  #     - name: Download coverage
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         pattern: coverage-*
-  #         merge-multiple: true
-
-  #     - name: Combine coverage
-  #       run: |
-  #         coverage combine
-  #         coverage xml -i
-
-  #     - name: Upload coverage to Code Climate
-  #       uses: paambaati/codeclimate-action@v3.0.0
-  #       env:
-  #         CC_TEST_REPORTER_ID: ${{ secrets.COV_TOKEN }}
-  #       with:
-  #         coverageLocations: .coverage.xml:coverage.py

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
     <a href="https://pypi.org/project/wom.py"><img height="20" alt="Stable version" src="https://img.shields.io/pypi/v/wom.py?label=stable&logo=pypi"></a>
     <a href="https://github.com/Jonxslays/wom.py/blob/master/LICENSE"><img height="20" alt="License" src="https://img.shields.io/pypi/l/wom-py?label=license"></a>
     <a href="https://python.org"><img height="20" alt="Python versions" src="https://img.shields.io/pypi/pyversions/wom-py?label=python&logo=python"></a>
+    <a href="https://codecov.io/gh/Jonxslays/wom.py" > <img src="https://codecov.io/gh/Jonxslays/wom.py/graph/badge.svg?token=I0WKWO5EC5"/></a>
 </div>
 
 An asynchronous wrapper for the [Wise Old Man API](https://docs.wiseoldman.net/).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <a href="https://pypi.org/project/wom.py"><img height="20" alt="Stable version" src="https://img.shields.io/pypi/v/wom.py?label=stable&logo=pypi"></a>
     <a href="https://github.com/Jonxslays/wom.py/blob/master/LICENSE"><img height="20" alt="License" src="https://img.shields.io/pypi/l/wom-py?label=license"></a>
     <a href="https://python.org"><img height="20" alt="Python versions" src="https://img.shields.io/pypi/pyversions/wom-py?label=python&logo=python"></a>
-    <a href="https://codecov.io/gh/Jonxslays/wom.py" > <img src="https://codecov.io/gh/Jonxslays/wom.py/graph/badge.svg?token=I0WKWO5EC5"/></a>
+    <a href="https://codecov.io/gh/Jonxslays/wom.py"><img src="https://codecov.io/gh/Jonxslays/wom.py/graph/badge.svg?token=I0WKWO5EC5"></a>
 </div>
 
 An asynchronous wrapper for the [Wise Old Man API](https://docs.wiseoldman.net/).

--- a/noxfile.py
+++ b/noxfile.py
@@ -80,16 +80,16 @@ def run(session: nox.Session, *args: str) -> None:
 
 
 @nox.session(reuse_venv=True)
-@install("pytest", "pytest-asyncio", "pytest-testdox", "coverage", "aiohttp", "msgspec")
+@install(
+    "pytest", "pytest-asyncio", "pytest-cov", "pytest-testdox", "coverage", "aiohttp", "msgspec"
+)
 def tests(session: nox.Session) -> None:
     run(
         session,
-        "coverage",
-        "run",
-        "--omit",
-        "tests/*",
-        "-m",
         "pytest",
+        "--cov",
+        "--cov-branch",
+        "--cov-report=xml",
         "--testdox",
         "--log-level=INFO",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "pyright==1.1.393",
     "pytest==8.3.4",
     "pytest-asyncio==0.25.3",
+    "pytest-cov==6.0.0",
     "pytest-testdox==3.1.0",
     "ruff==0.14.4",
 ]
@@ -66,6 +67,9 @@ reportImportCycles = false
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+
+[tool.coverage.run]
+omit = ["tests/*"]
 
 [tool.ruff]
 line-length = 99

--- a/uv.lock
+++ b/uv.lock
@@ -538,6 +538,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/70/de81bfec9ed38a64fc44a77c7665e20ca507fc3265597c28b0d989e4082e/coverage-7.6.10-pp39.pp310-none-any.whl", hash = "sha256:fd34e7b3405f0cc7ab03d54a334c17a9e802897580d964bd8c2001f4b9fd488f", size = 200223, upload-time = "2024-12-26T16:59:16.968Z" },
 ]
 
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
 [[package]]
 name = "distlib"
 version = "0.4.3"
@@ -1682,6 +1687,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/45/9b538de8cef30e17c7b45ef42f538a94889ed6a16f2387a6c89e73220651/pytest-cov-6.0.0.tar.gz", hash = "sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0", size = 66945, upload-time = "2024-10-29T20:13:35.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/3b/48e79f2cd6a61dbbd4807b4ed46cb564b4fd50a76166b1c4ea5c1d9e2371/pytest_cov-6.0.0-py3-none-any.whl", hash = "sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35", size = 22949, upload-time = "2024-10-29T20:13:33.215Z" },
+]
+
+[[package]]
 name = "pytest-testdox"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2127,6 +2145,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "pytest-testdox" },
     { name = "ruff" },
 ]
@@ -2150,6 +2169,7 @@ dev = [
     { name = "pyright", specifier = "==1.1.393" },
     { name = "pytest", specifier = "==8.3.4" },
     { name = "pytest-asyncio", specifier = "==0.25.3" },
+    { name = "pytest-cov", specifier = "==6.0.0" },
     { name = "pytest-testdox", specifier = "==3.1.0" },
     { name = "ruff", specifier = "==0.14.4" },
 ]


### PR DESCRIPTION
## Summary

Replaces the (commented-out) CodeClimate coverage pipeline with Codecov.

- Add `pytest-cov` to the dev dependency group.
- Switch the `tests` nox session from `coverage run -m pytest` to
  `pytest --cov --cov-branch --cov-report=xml`, adding branch coverage and a
  `coverage.xml` report.
- Add a `[tool.coverage.run]` `omit = ["tests/*"]` config to preserve the
  previous `--omit tests/*` behavior (since `pytest --cov` with no source
  measures everything).
- In CI, upload `coverage.xml` to Codecov from the test matrix using
  `codecov/codecov-action` (pinned by SHA to `v5.5.1`, matching the repo's
  action-pinning style) with `secrets.CODECOV_TOKEN`.
- Remove the per-matrix coverage artifact upload and the old commented-out
  CodeClimate combine job; Codecov merges the matrix uploads server-side.

## Notes

- `CODECOV_TOKEN` has already been added as a repo secret.
- The `coverage` nox session is unchanged and still works (pytest-cov writes
  `.coverage`, now with branch data).

## Verification

- `nox -s tests` passes (180 tests, writes `coverage.xml`).
- `nox -s coverage` reports 99% with branch columns.
- `nox -s formatting` passes.
