### PR TITLE
Enable prev/next footer navigation in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Changes
+
+- Enable next/back navigation buttons on all documentation pages.
+
 # v3.3.0 (Aug 2026)
 
 ## Additions

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.top
+    - navigation.footer
     - content.tabs.link
 
   icon:


### PR DESCRIPTION
## Summary

Turns on Material for MkDocs' `navigation.footer` theme feature so every docs page shows next/back buttons that follow the `nav:` order.

## Why it works across all versions

The buttons are generated automatically from the nav order and use **relative** hrefs (e.g. `../installation/`, `../services/`). No `stable`/`dev`/`vX.X.X` is hardcoded, so they resolve correctly under any `mike` version path.

Verified with a `mkdocs build`: on the Getting Started pages the buttons render as `Previous: Installation` → `Next: Wom services`, chaining through Installation → Client → Services → Result and linking across sections at the boundaries.

## Changes

- `mkdocs.yml`: add `navigation.footer` to theme features (one line).
- `CHANGELOG.md`: add an `Unreleased` section noting the docs change.