### PR TITLE
Improve docs accuracy and onboarding flow

### DIFF
--- a/.claude/rules/conventions.md
+++ b/.claude/rules/conventions.md
@@ -42,7 +42,9 @@ verbatim from any existing file when creating a new one.
 
 ## Docstrings
 
-Google-style docstrings on public classes and methods. They frequently include:
+NumPy-style docstrings on public classes and methods (a summary line, then
+`Parameters` / `Returns` sections under `----------` underlines; this matches
+`docstring_style: numpy` in `mkdocs.yml`). They frequently include:
 
 - mkdocs admonitions: `!!! note`, `!!! warning`, `!!! info`, `!!! tip`,
   `??? example` (collapsible), `!!! success` / `!!! failure`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 ## Changes
 
 - Enable next/back navigation buttons on all documentation pages.
+- Add a "Supported endpoints" docs page listing every service method, and
+  document the `general` service in the getting-started guides.
+- Order the getting-started section ahead of the module reference in the docs
+  navigation, and add short intros to the reference pages.
+
+## Documentation fixes
+
+- Correct the name-change service accessor in the docs from `Client.name_changes`
+  to `Client.names`.
+- Correct the stated minimum Python version in the installation guide from 3.9
+  to 3.10.
 
 # v3.3.0 (Aug 2026)
 

--- a/docs/getting-started/client.md
+++ b/docs/getting-started/client.md
@@ -8,8 +8,9 @@ Services available on the client include:
 - [`CompetitionService`][wom.CompetitionService] via `Client.competitions`
 - [`DeltaService`][wom.DeltaService] via `Client.deltas`
 - [`EfficiencyService`][wom.EfficiencyService] via `Client.efficiency`
+- [`GeneralService`][wom.GeneralService] via `Client.general`
 - [`GroupService`][wom.GroupService] via `Client.groups`
-- [`NameChangeService`][wom.NameChangeService] via `Client.name_changes`
+- [`NameChangeService`][wom.NameChangeService] via `Client.names`
 - [`PlayerService`][wom.PlayerService] via `Client.players`
 - [`RecordService`][wom.RecordService] via `Client.records`
 

--- a/docs/getting-started/endpoints.md
+++ b/docs/getting-started/endpoints.md
@@ -1,0 +1,123 @@
+# Supported endpoints
+
+wom.py aims to provide one service method for every endpoint of the
+[Wise Old Man API](https://docs.wiseoldman.net/). This page lists what is
+currently available, grouped by [service](services.md). Each service is a
+property on the [`Client`][wom.Client].
+
+Every method returns a [`Result`][wom.Result] - see the
+[result guide](result.md) - and the linked reference pages document their full
+signatures.
+
+## Players - `client.players`
+
+[`PlayerService`][wom.PlayerService]
+
+| Method | Description |
+| --- | --- |
+| `search_players` | Searches for a player by partial username. |
+| `update_player` | Updates the given player. |
+| `assert_player_type` | Asserts, and fixes, a player's type. |
+| `get_details` | Gets the details for a given player. |
+| `get_details_by_id` | Gets the details for a given player id. |
+| `get_achievements` | Gets the achievements for a given player. |
+| `get_achievement_progress` | Gets the progress towards achievements for a given player. |
+| `get_competition_participations` | Gets the competition participations for a given player. |
+| `get_competition_standings` | Gets the competition standings for a given player. |
+| `get_group_memberships` | Gets the group memberships for the given player. |
+| `get_gains` | Gets the gains made by a player over the given time span. |
+| `get_records` | Gets the records held by a player. |
+| `get_snapshots` | Gets the snapshots for a player. |
+| `get_snapshots_timeline` | Gets the snapshots timeline for a given player and metric. |
+| `get_name_changes` | Gets the name changes for a player. |
+| `get_archives` | Gets the archives for a given player. |
+
+## Groups - `client.groups`
+
+[`GroupService`][wom.GroupService]
+
+| Method | Description |
+| --- | --- |
+| `search_groups` | Searches for groups that partially match the given name. |
+| `get_details` | Gets the details for a given group id. |
+| `create_group` | Creates a new group. |
+| `edit_group` | Edits an existing group. |
+| `delete_group` | Deletes an existing group. |
+| `add_members` | Adds members to an existing group. |
+| `remove_members` | Removes members from an existing group. |
+| `change_member_role` | Changes the role for a member in an existing group. |
+| `update_outdated_members` | Attempts to update all outdated group members. |
+| `get_competitions` | Gets competitions for a given group. |
+| `get_gains` | Gets the gains for a group over a time frame. |
+| `get_bulk_gains` | Gets the bulk gains of all metrics for a group over a time frame. |
+| `get_achievements` | Gets the achievements for the group. |
+| `get_records` | Gets the records held by players in the group. |
+| `get_hiscores` | Gets the hiscores for the group. |
+| `get_bulk_hiscores` | Gets the bulk hiscores for the group. |
+| `get_name_changes` | Gets the past name changes for the group. |
+| `get_statistics` | Gets the statistics for the group. |
+| `get_activity` | Gets the activity for the group (paginated). |
+| `get_members_csv` | Gets members in the group in CSV format. |
+
+## Competitions - `client.competitions`
+
+[`CompetitionService`][wom.CompetitionService]
+
+| Method | Description |
+| --- | --- |
+| `search_competitions` | Searches for competitions with the given criteria. |
+| `get_details` | Gets details for the given competition. |
+| `get_top_participant_history` | Gets the history for the top 5 progressing participants. |
+| `create_competition` | Creates a new competition. |
+| `edit_competition` | Edits an existing competition. |
+| `delete_competition` | Deletes a competition. |
+| `add_participants` | Adds participants to a competition. |
+| `remove_participants` | Removes participants from a competition. |
+| `add_teams` | Adds teams to a competition. |
+| `remove_teams` | Removes teams from a competition. |
+| `update_outdated_participants` | Attempts to update all outdated competition participants. |
+| `get_details_csv` | Gets details about the competition in CSV format. |
+
+## Name changes - `client.names`
+
+[`NameChangeService`][wom.NameChangeService]
+
+| Method | Description |
+| --- | --- |
+| `search_name_changes` | Searches for name changes. |
+| `submit_name_change` | Submits a new name change. |
+| `bulk_submit_name_changes` | Submits multiple name changes at once. |
+| `get_name_change_details` | Gets the details of a name change. |
+
+## Deltas - `client.deltas`
+
+[`DeltaService`][wom.DeltaService]
+
+| Method | Description |
+| --- | --- |
+| `get_global_leaderboards` | Gets the top global delta leaderboard for a metric. |
+
+## Records - `client.records`
+
+[`RecordService`][wom.RecordService]
+
+| Method | Description |
+| --- | --- |
+| `get_global_leaderboards` | Gets the global record leaderboards. |
+
+## Efficiency - `client.efficiency`
+
+[`EfficiencyService`][wom.EfficiencyService]
+
+| Method | Description |
+| --- | --- |
+| `get_global_leaderboards` | Gets the top global efficiency leaderboard. |
+| `get_rates` | Gets the efficiency rates for a given algorithm type and metric. |
+
+## General - `client.general`
+
+[`GeneralService`][wom.GeneralService]
+
+| Method | Description |
+| --- | --- |
+| `get_stats` | Gets global statistics about the data tracked by WOM. |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Python version 3.9 or greater is required to use wom.py.
+Python version 3.10 or greater is required to use wom.py.
 
 ## Stable
 

--- a/docs/getting-started/result.md
+++ b/docs/getting-started/result.md
@@ -6,11 +6,26 @@ that go out over the network via the [`Client`][wom.Client] come back to you in
 the form of a [`Result`][wom.Result]. The result can be one of two things:
 an [`Ok`][wom.Ok] or an [`Err`][wom.Err].
 
-Calling [`unwrap()`][wom.Result.unwrap] on an [`Err`][wom.Err] will raise an
-exception.
+!!! info
 
-Calling [`unwrap_err()`][wom.Result.unwrap_err] on an [`Ok`][wom.Ok] will raise
-an exception.
+    Service methods **never raise** on an API error. A failed request comes back
+    as an [`Err`][wom.Err] wrapping an
+    [`HttpErrorResponse`][wom.HttpErrorResponse], so you branch on the result
+    instead of wrapping calls in `try`/`except`.
+
+## The API
+
+- [`is_ok`][wom.Result.is_ok] / [`is_err`][wom.Result.is_err] - booleans
+  identifying the variant.
+- [`unwrap()`][wom.Result.unwrap] - returns the value on an [`Ok`][wom.Ok];
+  raises [`UnwrapError`][wom.UnwrapError] on an [`Err`][wom.Err].
+- [`unwrap_err()`][wom.Result.unwrap_err] - returns the error on an
+  [`Err`][wom.Err]; raises [`UnwrapError`][wom.UnwrapError] on an [`Ok`][wom.Ok].
+- [`to_dict()`][wom.Result.to_dict] - `{"value": ..., "error": None}` for an
+  [`Ok`][wom.Ok], and the mirror for an [`Err`][wom.Err].
+
+Always check [`is_ok`][wom.Result.is_ok] (or [`is_err`][wom.Result.is_err])
+before unwrapping, so you unwrap the variant you actually have.
 
 ## Correct usage
 

--- a/docs/getting-started/services.md
+++ b/docs/getting-started/services.md
@@ -10,6 +10,7 @@ to those endpoints.
 - [`CompetitionService`][wom.CompetitionService] for requests related to competitions.
 - [`DeltaService`][wom.DeltaService] for requests related to deltas.
 - [`EfficiencyService`][wom.EfficiencyService] for requests related to efficiency.
+- [`GeneralService`][wom.GeneralService] for general requests not specific to a domain.
 - [`GroupService`][wom.GroupService] for requests related to groups.
 - [`NameChangeService`][wom.NameChangeService] for requests related to name changes.
 - [`PlayerService`][wom.PlayerService] for requests related to players.
@@ -28,7 +29,7 @@ client = wom.Client()
 await client.start()
 
 # Use the name change service to submit a name change
-result = await client.name_changes.submit_name_change("old name", "new name")
+result = await client.names.submit_name_change("old name", "new name")
 
 # ... Do something with the result here
 

--- a/docs/reference/client.md
+++ b/docs/reference/client.md
@@ -1,3 +1,7 @@
 # client
 
+The [`Client`][wom.Client] is the entry point to the library. It owns the HTTP
+session and exposes one service per API domain. See the
+[client guide](../getting-started/client.md) for setup and lifecycle.
+
 ::: wom.client

--- a/docs/reference/enums.md
+++ b/docs/reference/enums.md
@@ -1,3 +1,7 @@
 # enums
 
+Enumerations shared across the library - metrics, periods, player types, and the
+like. Members are PascalCase names mapped to the API's string values, so
+`wom.Metric.Attack` serializes to `"attack"`.
+
 ::: wom.enums

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -1,3 +1,7 @@
 # errors
 
+Exception types raised by the library. Note that API errors do **not** raise -
+they come back as an [`Err`][wom.Err]; these exceptions cover misuse such as
+unwrapping the wrong [`Result`][wom.Result] variant.
+
 ::: wom.errors

--- a/docs/reference/models.md
+++ b/docs/reference/models.md
@@ -1,3 +1,7 @@
 # models
 
+Typed model classes returned by the service methods. Every response the WOM API
+sends is deserialized into one of these; the API's camelCase fields map to the
+snake_case attributes documented below.
+
 ::: wom.models

--- a/docs/reference/result.md
+++ b/docs/reference/result.md
@@ -1,3 +1,7 @@
 # result
 
+The [`Result`][wom.Result] type returned by every service method, along with its
+[`Ok`][wom.Ok] and [`Err`][wom.Err] variants. See the
+[result guide](../getting-started/result.md) for how to branch on it.
+
 ::: wom.result

--- a/docs/reference/routes.md
+++ b/docs/reference/routes.md
@@ -1,3 +1,7 @@
 # routes
 
+The internal route constants used to build requests. Most users never touch
+these directly - services compile them for you - but they are documented here for
+completeness.
+
 ::: wom.routes

--- a/docs/reference/serializer.md
+++ b/docs/reference/serializer.md
@@ -1,3 +1,7 @@
 # serializer
 
+The internal component that encodes requests and decodes responses into
+[models](models.md). Owned by the [`Client`][wom.Client]; you should not need to
+use it directly.
+
 ::: wom.serializer

--- a/docs/reference/services.md
+++ b/docs/reference/services.md
@@ -1,3 +1,8 @@
 # services
 
+Each service groups the requests for one area of the WOM API and is accessed as
+a property on the [`Client`][wom.Client] (e.g. `client.players`). For a
+high-level tour see the [services guide](../getting-started/services.md) and the
+[supported endpoints](../getting-started/endpoints.md) list.
+
 ::: wom.services

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,12 @@ site_url: https://jonxslays.github.io/wom.py/
 
 nav:
   - "index.md"
+  - "Getting started":
+      - "getting-started/installation.md"
+      - "getting-started/client.md"
+      - "getting-started/services.md"
+      - "getting-started/endpoints.md"
+      - "getting-started/result.md"
   - "Modules":
       - "reference/client.md"
       - "reference/enums.md"
@@ -96,11 +102,6 @@ nav:
       - "reference/routes.md"
       - "reference/serializer.md"
       - "reference/services.md"
-  - "Getting started":
-      - "getting-started/installation.md"
-      - "getting-started/client.md"
-      - "getting-started/services.md"
-      - "getting-started/result.md"
   - "Migration guides":
       - "migrating/v1.md"
       - "migrating/v2.md"


### PR DESCRIPTION
## Summary

A documentation pass covering accuracy fixes, structure, and coverage. No code changes.

### Corrections (previously shipped bugs)
- **`Client.name_changes` → `Client.names`.** The documented accessor was wrong; the real property is `client.names`, so the old snippets would raise `AttributeError`. Fixed in the client guide, services guide, and the new endpoints page.
- **Minimum Python version 3.9 → 3.10** in the installation guide, matching `requires-python = ">=3.10"` (3.9 support was dropped in v3).
- **Docstring-style rule:** `.claude/rules/conventions.md` said "Google-style" but the code and `mkdocs.yml` use **NumPy-style**. Corrected the rule.

### Additions
- New **Supported endpoints** page (`getting-started/endpoints.md`) listing every service method grouped by domain, wired into the nav.
- Documented the previously-undocumented **`general` service** (`client.general` / `get_stats`) in the getting-started guides.
- Short intros on the eight bare `reference/*.md` pages (they were single `::: wom.x` dumps).
- Fleshed out the result guide: `is_err`, `to_dict`, and a "service methods never raise" note, all cross-linked.

### Structure
- Reordered the nav so **Getting started** comes before the module reference, so the forward/prev-next path matches the onboarding path.

## Verification
- `uv run mkdocs build --strict` passes, so all `[Type][wom.Type]` cross-references resolve.
- Confirmed `HttpErrorResponse`, `UnwrapError`, and `GeneralService` are public before linking them.